### PR TITLE
feat(kanban): add per-column add button with inline input

### DIFF
--- a/app/_components/FeatureComponents/Kanban/Kanban.tsx
+++ b/app/_components/FeatureComponents/Kanban/Kanban.tsx
@@ -219,6 +219,7 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
                 isShared={isShared}
                 statusColor={statuses.find((s) => s.id === column.id)?.color}
                 statuses={statuses}
+                onAddItem={permissions?.canEdit ? (text) => handleAddItem(text, undefined, column.status) : undefined}
               />
             </div>
           );

--- a/app/_components/FeatureComponents/Kanban/KanbanColumn.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, memo } from "react";
+import { useMemo, memo, useState, useRef, useEffect } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -11,7 +11,7 @@ import { KanbanCard } from "./KanbanCard";
 import { cn } from "@/app/_utils/global-utils";
 import { TaskStatus } from "@/app/_types/enums";
 import { useTranslations } from "next-intl";
-import { TaskDaily01Icon } from "hugeicons-react";
+import { TaskDaily01Icon, Add01Icon } from "hugeicons-react";
 
 interface KanbanColumnProps {
   checklist: Checklist;
@@ -25,7 +25,48 @@ interface KanbanColumnProps {
   isShared: boolean;
   statusColor?: string;
   statuses: KanbanStatus[];
+  onAddItem?: (status: string) => Promise<void>;
 }
+
+interface InlineAddInputProps {
+  onSubmit: (text: string) => void;
+  onCancel: () => void;
+  placeholder: string;
+  isLoading?: boolean;
+}
+
+const InlineAddInput = ({ onSubmit, onCancel, placeholder, isLoading }: InlineAddInputProps) => {
+  const [text, setText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (text.trim()) onSubmit(text.trim());
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={() => { if (!text.trim()) onCancel(); }}
+      placeholder={placeholder}
+      disabled={isLoading}
+      className="w-full px-2 py-1.5 text-xs bg-background border border-input rounded-jotty focus:outline-none focus:border-ring transition-colors"
+    />
+  );
+};
 
 const KanbanColumnComponent = ({
   checklist,
@@ -39,11 +80,15 @@ const KanbanColumnComponent = ({
   onUpdate,
   statusColor,
   statuses,
+  onAddItem,
 }: KanbanColumnProps) => {
   const t = useTranslations();
-  const { setNodeRef, isOver } = useDroppable({
-    id,
-  });
+  const { setNodeRef, isOver } = useDroppable({ id });
+  const [showInlineInput, setShowInlineInput] = useState(false);
+  const [isAddingItem, setIsAddingItem] = useState(false);
+
+  const currentStatus = statuses.find((s) => s.id === status);
+  const isAutoComplete = currentStatus?.autoComplete === true;
 
   const defaultColors: Record<string, string> = useMemo(
     () => ({
@@ -76,6 +121,14 @@ const KanbanColumnComponent = ({
     };
   }, [color]);
 
+  const handleInlineSubmit = async (text: string) => {
+    if (!onAddItem) return;
+    setIsAddingItem(true);
+    setShowInlineInput(false);
+    await onAddItem(text);
+    setIsAddingItem(false);
+  };
+
   return (
     <div className="flex flex-col h-full my-4 lg:my-0 min-w-0">
       <div className="flex items-center justify-between mb-3 min-w-0">
@@ -86,9 +139,22 @@ const KanbanColumnComponent = ({
           />
           <h3 className="font-medium text-md lg:text-sm text-foreground truncate">{title}</h3>
         </div>
-        <span className="text-md lg:text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full shrink-0">
-          {items.length}
-        </span>
+        <div className="flex items-center gap-1 shrink-0">
+          {onAddItem && !isAutoComplete && (
+            <button
+              onClick={() => setShowInlineInput(true)}
+              title={t("kanban.addItemToColumn", { column: title })}
+              aria-label={t("kanban.addItemToColumn", { column: title })}
+              disabled={isAddingItem || showInlineInput}
+              className="flex items-center justify-center h-5 w-5 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Add01Icon className="h-3.5 w-3.5" />
+            </button>
+          )}
+          <span className="text-md lg:text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full">
+            {items.length}
+          </span>
+        </div>
       </div>
 
       <div
@@ -108,6 +174,13 @@ const KanbanColumnComponent = ({
           strategy={verticalListSortingStrategy}
         >
           <div className="space-y-2">
+            {showInlineInput && (
+              <InlineAddInput
+                onSubmit={handleInlineSubmit}
+                onCancel={() => setShowInlineInput(false)}
+                placeholder={t("kanban.addItemPlaceholder")}
+              />
+            )}
             {items.map((item) => (
               <KanbanCard
                 checklist={checklist}
@@ -121,7 +194,7 @@ const KanbanColumnComponent = ({
                 statusColor={statusColor}
               />
             ))}
-            {items.length === 0 && (
+            {items.length === 0 && !showInlineInput && (
               <div className="flex flex-col items-center justify-center text-muted-foreground/50 py-8 gap-2">
                 <TaskDaily01Icon className="h-8 w-8" />
                 <span className="text-md lg:text-sm">{t('checklists.noTasks')}</span>

--- a/app/_components/FeatureComponents/Kanban/KanbanColumn.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanColumn.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/app/_utils/global-utils";
 import { TaskStatus } from "@/app/_types/enums";
 import { useTranslations } from "next-intl";
 import { TaskDaily01Icon, Add01Icon } from "hugeicons-react";
+import { Input } from "../../GlobalComponents/FormElements/Input";
 
 interface KanbanColumnProps {
   checklist: Checklist;
@@ -35,7 +36,12 @@ interface InlineAddInputProps {
   isLoading?: boolean;
 }
 
-const InlineAddInput = ({ onSubmit, onCancel, placeholder, isLoading }: InlineAddInputProps) => {
+const InlineAddInput = ({
+  onSubmit,
+  onCancel,
+  placeholder,
+  isLoading,
+}: InlineAddInputProps) => {
   const [text, setText] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -54,16 +60,17 @@ const InlineAddInput = ({ onSubmit, onCancel, placeholder, isLoading }: InlineAd
   };
 
   return (
-    <input
-      ref={inputRef}
+    <Input
+      id="inline-add-input"
       type="text"
       value={text}
       onChange={(e) => setText(e.target.value)}
       onKeyDown={handleKeyDown}
-      onBlur={() => { if (!text.trim()) onCancel(); }}
+      onBlur={() => {
+        if (!text.trim()) onCancel();
+      }}
       placeholder={placeholder}
       disabled={isLoading}
-      className="w-full px-2 py-1.5 text-xs bg-background border border-input rounded-jotty focus:outline-none focus:border-ring transition-colors"
     />
   );
 };
@@ -97,7 +104,7 @@ const KanbanColumnComponent = ({
       [TaskStatus.COMPLETED]: "#10b981",
       [TaskStatus.PAUSED]: "#f59e0b",
     }),
-    []
+    [],
   );
 
   const color = statusColor || defaultColors[status] || "#6b7280";
@@ -107,10 +114,10 @@ const KanbanColumnComponent = ({
       const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
       return result
         ? {
-          r: parseInt(result[1], 16),
-          g: parseInt(result[2], 16),
-          b: parseInt(result[3], 16),
-        }
+            r: parseInt(result[1], 16),
+            g: parseInt(result[2], 16),
+            b: parseInt(result[3], 16),
+          }
         : null;
     };
 
@@ -137,7 +144,9 @@ const KanbanColumnComponent = ({
             className="w-3 h-3 rounded-full shrink-0"
             style={{ backgroundColor: color }}
           />
-          <h3 className="font-medium text-md lg:text-sm text-foreground truncate">{title}</h3>
+          <h3 className="font-medium text-md lg:text-sm text-foreground truncate">
+            {title}
+          </h3>
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {onAddItem && !isAutoComplete && (
@@ -162,7 +171,7 @@ const KanbanColumnComponent = ({
         aria-label={`${title} column`}
         className={cn(
           "flex-1 min-w-0 rounded-jotty border-2 border-dashed p-3 min-h-[200px] transition-colors duration-200",
-          isOver && "border-primary/70 bg-primary/10 shadow-md"
+          isOver && "border-primary/70 bg-primary/10 shadow-md",
         )}
         style={{
           borderColor: isOver ? undefined : borderColor,
@@ -197,7 +206,9 @@ const KanbanColumnComponent = ({
             {items.length === 0 && !showInlineInput && (
               <div className="flex flex-col items-center justify-center text-muted-foreground/50 py-8 gap-2">
                 <TaskDaily01Icon className="h-8 w-8" />
-                <span className="text-md lg:text-sm">{t('checklists.noTasks')}</span>
+                <span className="text-md lg:text-sm">
+                  {t("checklists.noTasks")}
+                </span>
               </div>
             )}
           </div>

--- a/app/_hooks/kanban/useKanban.ts
+++ b/app/_hooks/kanban/useKanban.ts
@@ -296,7 +296,7 @@ export const useKanbanBoard = ({
     }
   };
 
-  const handleAddItem = async (text: string, recurrence?: RecurrenceRule) => {
+  const handleAddItem = async (text: string, recurrence?: RecurrenceRule, status?: string) => {
     setIsLoading(true);
     const formData = new FormData();
     formData.append("listId", localChecklist.id);
@@ -307,6 +307,10 @@ export const useKanbanBoard = ({
 
     if (recurrence) {
       formData.append("recurrence", JSON.stringify(recurrence));
+    }
+
+    if (status) {
+      formData.append("status", status);
     }
 
     const result = await createItem(

--- a/app/_translations/de.json
+++ b/app/_translations/de.json
@@ -600,7 +600,9 @@
     "session": "Sitzung",
     "sessions": "Sitzungen",
     "startTime": "Start",
-    "endTime": "Ende"
+    "endTime": "Ende",
+    "addItemToColumn": "Element zu {column} hinzufügen",
+    "addItemPlaceholder": "Neues Element..."
   },
   "profile": {
     "userProfile": "Benutzer",

--- a/app/_translations/en.json
+++ b/app/_translations/en.json
@@ -625,7 +625,9 @@
     "session": "session",
     "sessions": "sessions",
     "startTime": "Start",
-    "endTime": "End"
+    "endTime": "End",
+    "addItemToColumn": "Add item to {column}",
+    "addItemPlaceholder": "New item..."
   },
   "profile": {
     "userProfile": "User",

--- a/app/_translations/es.json
+++ b/app/_translations/es.json
@@ -600,7 +600,9 @@
     "session": "sesión",
     "sessions": "sesiones",
     "startTime": "Inicio",
-    "endTime": "Fin"
+    "endTime": "Fin",
+    "addItemToColumn": "Agregar elemento a {column}",
+    "addItemPlaceholder": "Nuevo elemento..."
   },
   "profile": {
     "userProfile": "Usuario",

--- a/app/_translations/fr.json
+++ b/app/_translations/fr.json
@@ -600,7 +600,9 @@
     "session": "session",
     "sessions": "sessions",
     "startTime": "Début",
-    "endTime": "Fin"
+    "endTime": "Fin",
+    "addItemToColumn": "Ajouter un élément à {column}",
+    "addItemPlaceholder": "Nouvel élément..."
   },
   "profile": {
     "userProfile": "Utilisateur",

--- a/app/_translations/it.json
+++ b/app/_translations/it.json
@@ -600,7 +600,9 @@
     "session": "sessione",
     "sessions": "sessioni",
     "startTime": "Inizio",
-    "endTime": "Fine"
+    "endTime": "Fine",
+    "addItemToColumn": "Aggiungi elemento a {column}",
+    "addItemPlaceholder": "Nuovo elemento..."
   },
   "profile": {
     "userProfile": "Utente",

--- a/app/_translations/klingon.json
+++ b/app/_translations/klingon.json
@@ -625,7 +625,9 @@
     "session": "meeting wa'",
     "sessions": "meeting",
     "startTime": "qaStaHvIS",
-    "endTime": "bav"
+    "endTime": "bav",
+    "addItemToColumn": "{column} chel",
+    "addItemPlaceholder": "chu' De'..."
   },
   "profile": {
     "userProfile": "lo'wI'",

--- a/app/_translations/ko.json
+++ b/app/_translations/ko.json
@@ -625,7 +625,9 @@
     "session": "세션",
     "sessions": "세션",
     "startTime": "시작",
-    "endTime": "종료"
+    "endTime": "종료",
+    "addItemToColumn": "{column}에 항목 추가",
+    "addItemPlaceholder": "새 항목..."
   },
   "profile": {
     "userProfile": "사용자",

--- a/app/_translations/nl.json
+++ b/app/_translations/nl.json
@@ -600,7 +600,9 @@
     "session": "sessie",
     "sessions": "sessies",
     "startTime": "Start",
-    "endTime": "Einde"
+    "endTime": "Einde",
+    "addItemToColumn": "Item toevoegen aan {column}",
+    "addItemPlaceholder": "Nieuw item..."
   },
   "profile": {
     "userProfile": "Gebruiker",

--- a/app/_translations/pirate.json
+++ b/app/_translations/pirate.json
@@ -625,7 +625,9 @@
     "session": "watch",
     "sessions": "watches",
     "startTime": "Start o’ bell",
-    "endTime": "End o’ bell"
+    "endTime": "End o’ bell",
+    "addItemToColumn": "Plunder {column} with a new item",
+    "addItemPlaceholder": "New plunder..."
   },
   "profile": {
     "userProfile": "Deckhand",

--- a/app/_translations/pl.json
+++ b/app/_translations/pl.json
@@ -600,7 +600,9 @@
     "session": "sesja",
     "sessions": "sesje",
     "startTime": "Początek",
-    "endTime": "Koniec"
+    "endTime": "Koniec",
+    "addItemToColumn": "Dodaj element do {column}",
+    "addItemPlaceholder": "Nowy element..."
   },
   "profile": {
     "userProfile": "Użytkownik",

--- a/app/_translations/ru.json
+++ b/app/_translations/ru.json
@@ -625,7 +625,9 @@
     "session": "сессия",
     "sessions": "сессии",
     "startTime": "Начало",
-    "endTime": "Конец"
+    "endTime": "Конец",
+    "addItemToColumn": "Добавить элемент в {column}",
+    "addItemPlaceholder": "Новый элемент..."
   },
   "profile": {
     "userProfile": "Пользователь",

--- a/app/_translations/tr.json
+++ b/app/_translations/tr.json
@@ -625,7 +625,9 @@
     "session": "oturum",
     "sessions": "oturum",
     "startTime": "Başlangıç",
-    "endTime": "Bitiş"
+    "endTime": "Bitiş",
+    "addItemToColumn": "{column} sütununa öğe ekle",
+    "addItemPlaceholder": "Yeni öğe..."
   },
   "profile": {
     "userProfile": "Kullanıcı Profili",

--- a/app/_translations/zh.json
+++ b/app/_translations/zh.json
@@ -625,7 +625,9 @@
     "session": "记录",
     "sessions": "记录",
     "startTime": "开始",
-    "endTime": "结束"
+    "endTime": "结束",
+    "addItemToColumn": "添加项目到 {column}",
+    "addItemPlaceholder": "新项目..."
   },
   "profile": {
     "userProfile": "用户",


### PR DESCRIPTION
## Summary

- Adds a small "+" button to each Kanban column header that creates a new item
  directly in that column's status, removing the need for manual drag-and-drop
- The button is hidden for `autoComplete` columns (semantically no new items
  belong there) and when the user lacks edit permission
- Clicking "+" reveals a minimal inline text input at the top of the column;
  Enter saves, Esc or blur-without-text cancels
- Extends `handleAddItem` in `useKanban.ts` with an optional `status` parameter
  forwarded to the server action (which already supported it)
- Adds i18n keys `kanban.addItemToColumn` and `kanban.addItemPlaceholder` to
  all 13 locale files (only en and de verified, rest claude genereated translations)
  
  ## Executed tests

- Open a Kanban board, verify "+" appears in every non-autoComplete column header
- Click "+", type a name, press Enter — item appears in the correct column
- Click "+", press Esc — input disappears without creating an item
- Click "+", leave input blank, click away — input closes, nothing created
- Verify "+" does NOT appear on the autoComplete (Completed) column
- Test in multiple locales (de, en) that tooltip text is translated

## Open tests

- Verify "+" does NOT appear for a read-only/shared viewer (sharing did somehow not work in my dev setup)


🤖 Generated with [Claude Code](https://claude.com/claude-code)