### PR TITLE
fix(i18n): improve German translation for autoComplete toggle

### DIFF
--- a/app/_translations/de.json
+++ b/app/_translations/de.json
@@ -540,7 +540,7 @@
     "viewArchived": "Archivierte anzeigen",
     "customizeStatuses": "Passe die Status für dieses Kanban-Board an. Füge Status hinzu, entferne oder ordne sie neu.",
     "addStatus": "Status hinzufügen",
-    "autoComplete": "Automatische Vervollständigung"
+    "autoComplete": "Automatisch abschließen"
   },
   "kanban": {
     "priority": "Priorität",


### PR DESCRIPTION
## Summary

- The German translation for `tasks.autoComplete` was "Automatische Vervollständigung", which reads as "autocomplete" in the UI sense (e.g. text field suggestions / browser autofill).
- The actual feature marks a Kanban item as completed when it is moved to that column — i.e. it closes the task automatically.
- Updated to "Automatisch abschließen" ("automatically close/finish"), which correctly describes the behaviour.

## executed tests

- Open a Kanban board with German locale
- Click "Status verwalten" (Manage Statuses)
- Verify the toggle label reads "Automatisch abschließen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)