### PR TITLE
fix(scrollbar): consistent scrollbar styling across Firefox and Chromium browsers (Windows)

### DIFF
--- a/app/_components/FeatureComponents/Home/Parts/ChecklistHome.tsx
+++ b/app/_components/FeatureComponents/Home/Parts/ChecklistHome.tsx
@@ -164,7 +164,7 @@ export const ChecklistHome = ({
   }
 
   return (
-    <div className="h-full overflow-y-auto hide-scrollbar bg-background pb-16 lg:pb-0 jotty-scrollable-content">
+    <div className="h-full overflow-y-auto bg-background pb-16 lg:pb-0 jotty-scrollable-content">
       <div className="max-w-full pt-6 pb-4 px-4 lg:pt-8 lg:pb-8 lg:px-8">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6 lg:mb-8">
           <div className="flex items-center gap-3">

--- a/app/_components/FeatureComponents/Home/Parts/NotesHome.tsx
+++ b/app/_components/FeatureComponents/Home/Parts/NotesHome.tsx
@@ -159,7 +159,7 @@ export const NotesHome = ({
   }
 
   return (
-    <div className="flex-1 overflow-y-auto jotty-scrollable-content bg-background h-full hide-scrollbar">
+    <div className="flex-1 overflow-y-auto jotty-scrollable-content bg-background h-full">
       <div className="max-w-full pt-6 pb-4 px-4 lg:pt-8 lg:pb-8 lg:px-8">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6 lg:mb-8">
           <div className="flex items-center gap-3">

--- a/app/_components/FeatureComponents/Kanban/Kanban.tsx
+++ b/app/_components/FeatureComponents/Kanban/Kanban.tsx
@@ -388,7 +388,7 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
           )}
         </div>
       )}
-      <div className="flex-1 min-w-0 w-full max-w-full overflow-auto pb-[8.5em] scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">
+      <div className="flex-1 min-w-0 w-full max-w-full overflow-auto pb-[8.5em]">
         {viewMode === "calendar" ? (
           <div className="p-4">
             <CalendarView

--- a/app/_components/FeatureComponents/Kanban/Kanban.tsx
+++ b/app/_components/FeatureComponents/Kanban/Kanban.tsx
@@ -388,7 +388,7 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
           )}
         </div>
       )}
-      <div className="flex-1 min-w-0 w-full max-w-full overflow-auto pb-[8.5em]">
+      <div className="flex-1 min-w-0 w-full max-w-full overflow-auto pb-[8.5em] scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">
         {viewMode === "calendar" ? (
           <div className="p-4">
             <CalendarView

--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -327,9 +327,10 @@ export const KanbanCardDetail = ({
       isOpen={isOpen}
       onClose={onClose}
       title={item.text || t("checklists.untitledTask")}
-      className="jotty-kanban-detail-modal [&_.jotty-modal-header]:shrink-0 lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col lg:overflow-hidden"
+      size="fullscreen"
+      className="lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)]"
     >
-      <div className="flex flex-col lg:flex-row gap-6 lg:flex-1 lg:min-h-0 lg:overflow-hidden">
+      <div className="flex flex-col lg:flex-row gap-6 min-h-full lg:overflow-hidden p-6">
         <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 overflow-y-auto">
           {isEditing ? (
             <div className="space-y-4">

--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -327,7 +327,7 @@ export const KanbanCardDetail = ({
       isOpen={isOpen}
       onClose={onClose}
       title={item.text || t("checklists.untitledTask")}
-      className="[&_.jotty-modal-header]:shrink-0 [&>div:last-child]:flex-1 [&>div:last-child]:min-h-0 [&>div:last-child]:flex [&>div:last-child]:flex-col [&>div:last-child]:overflow-y-auto lg:[&>div:last-child]:overflow-hidden lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col lg:overflow-hidden"
+      className="jotty-kanban-detail-modal [&_.jotty-modal-header]:shrink-0 lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col lg:overflow-hidden"
     >
       <div className="flex flex-col lg:flex-row gap-6 lg:flex-1 lg:min-h-0 lg:overflow-hidden">
         <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 overflow-y-auto">

--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -327,10 +327,10 @@ export const KanbanCardDetail = ({
       isOpen={isOpen}
       onClose={onClose}
       title={item.text || t("checklists.untitledTask")}
-      className="[&_.jotty-modal-header]:shrink-0 [&>div:last-child]:flex-1 [&>div:last-child]:min-h-0 [&>div:last-child]:flex [&>div:last-child]:flex-col [&>div:last-child]:overflow-y-auto lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col lg:overflow-hidden"
+      className="[&_.jotty-modal-header]:shrink-0 [&>div:last-child]:flex-1 [&>div:last-child]:min-h-0 [&>div:last-child]:flex [&>div:last-child]:flex-col [&>div:last-child]:overflow-y-auto lg:[&>div:last-child]:overflow-hidden lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col lg:overflow-hidden"
     >
       <div className="flex flex-col lg:flex-row gap-6 lg:flex-1 lg:min-h-0 lg:overflow-hidden">
-        <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 lg:overflow-y-auto scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">
+        <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 overflow-y-auto">
           {isEditing ? (
             <div className="space-y-4">
               <div>
@@ -436,7 +436,7 @@ export const KanbanCardDetail = ({
           )}
         </div>
 
-        <div className="lg:w-80 lg:flex-shrink-0 lg:border-l lg:border-border lg:pl-6 lg:min-h-0 lg:overflow-y-auto scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">
+        <div className="lg:w-80 lg:flex-shrink-0 lg:border-l lg:border-border lg:pl-6 lg:min-h-0 overflow-y-auto">
           <KanbanCardDetailProperties
             item={item}
             priorityInput={priorityInput}

--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -327,7 +327,7 @@ export const KanbanCardDetail = ({
       isOpen={isOpen}
       onClose={onClose}
       title={item.text || t("checklists.untitledTask")}
-      className="[&_.jotty-modal-header]:shrink-0 lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col overflow-y-auto overscroll-contain lg:overflow-hidden"
+      className="[&_.jotty-modal-header]:shrink-0 [&>div:last-child]:flex-1 [&>div:last-child]:min-h-0 [&>div:last-child]:flex [&>div:last-child]:flex-col [&>div:last-child]:overflow-y-auto lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col lg:overflow-hidden"
     >
       <div className="flex flex-col lg:flex-row gap-6 lg:flex-1 lg:min-h-0 lg:overflow-hidden">
         <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 lg:overflow-y-auto scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">

--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -330,7 +330,7 @@ export const KanbanCardDetail = ({
       className="[&_.jotty-modal-header]:shrink-0 lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)] !flex !flex-col overflow-y-auto overscroll-contain lg:overflow-hidden"
     >
       <div className="flex flex-col lg:flex-row gap-6 lg:flex-1 lg:min-h-0 lg:overflow-hidden">
-        <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 lg:overflow-y-auto">
+        <div className="min-w-0 space-y-4 lg:flex-1 lg:min-h-0 lg:overflow-y-auto scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">
           {isEditing ? (
             <div className="space-y-4">
               <div>
@@ -436,7 +436,7 @@ export const KanbanCardDetail = ({
           )}
         </div>
 
-        <div className="lg:w-80 lg:flex-shrink-0 lg:border-l lg:border-border lg:pl-6 lg:min-h-0 lg:overflow-y-auto">
+        <div className="lg:w-80 lg:flex-shrink-0 lg:border-l lg:border-border lg:pl-6 lg:min-h-0 lg:overflow-y-auto scrollbar-thin scrollbar-thumb-primary/30 scrollbar-track-muted/50 scrollbar-thumb-rounded-md scrollbar-track-rounded-md">
           <KanbanCardDetailProperties
             item={item}
             priorityInput={priorityInput}

--- a/app/_components/GlobalComponents/Sidebar/SidebarWrapper.tsx
+++ b/app/_components/GlobalComponents/Sidebar/SidebarWrapper.tsx
@@ -115,7 +115,7 @@ export const SidebarWrapper = ({
           <div
             ref={internalScrollRef}
             onScroll={handleScroll}
-            className="jotty-sidebar-categories flex-1 overflow-y-auto scrollbar-thin p-2 space-y-2"
+            className="jotty-sidebar-categories flex-1 overflow-y-auto p-2 space-y-2"
           >
             <div className="pt-2">
               <div className="flex items-center justify-between">

--- a/app/_components/GlobalComponents/Sidebar/SidebarWrapper.tsx
+++ b/app/_components/GlobalComponents/Sidebar/SidebarWrapper.tsx
@@ -115,7 +115,7 @@ export const SidebarWrapper = ({
           <div
             ref={internalScrollRef}
             onScroll={handleScroll}
-            className="jotty-sidebar-categories flex-1 overflow-y-auto hide-scrollbar p-2 space-y-2"
+            className="jotty-sidebar-categories flex-1 overflow-y-auto scrollbar-thin p-2 space-y-2"
           >
             <div className="pt-2">
               <div className="flex items-center justify-between">

--- a/app/_styles/globals.css
+++ b/app/_styles/globals.css
@@ -662,6 +662,7 @@ pre.text-foreground span,
 
 @supports (-moz-appearance: none) {
     .overflow-y-auto,
+    .overflow-x-auto,
     .overflow-auto {
         scrollbar-width: thin;
         scrollbar-color: rgb(var(--primary) / 0.3) transparent;

--- a/app/_styles/globals.css
+++ b/app/_styles/globals.css
@@ -717,19 +717,6 @@ pre.text-foreground span,
     background-color: rgb(var(--primary) / 0.5);
 }
 
-.jotty-modal-content.jotty-kanban-detail-modal > div:last-child {
-    flex: 1 1 0%;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-}
-
-@media (min-width: 1024px) {
-    .jotty-modal-content.jotty-kanban-detail-modal > div:last-child {
-        overflow: hidden;
-    }
-}
 
 @media (max-width: 992px) {
   .jotty-checklist-page .jotty-quick-nav,

--- a/app/_styles/globals.css
+++ b/app/_styles/globals.css
@@ -717,6 +717,20 @@ pre.text-foreground span,
     background-color: rgb(var(--primary) / 0.5);
 }
 
+.jotty-modal-content.jotty-kanban-detail-modal > div:last-child {
+    flex: 1 1 0%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+@media (min-width: 1024px) {
+    .jotty-modal-content.jotty-kanban-detail-modal > div:last-child {
+        overflow: hidden;
+    }
+}
+
 @media (max-width: 992px) {
   .jotty-checklist-page .jotty-quick-nav,
   .jotty-embed .jotty-quick-nav {

--- a/app/_styles/globals.css
+++ b/app/_styles/globals.css
@@ -660,38 +660,61 @@ pre.text-foreground span,
   }
 }
 
-.overflow-y-auto {
-  scrollbar-width: auto !important;
+@supports (-moz-appearance: none) {
+    .overflow-y-auto,
+    .overflow-auto {
+        scrollbar-width: thin;
+        scrollbar-color: rgb(var(--primary) / 0.3) transparent;
+    }
 }
 
 .jotty-scrollable-content {
-  -webkit-overflow-scrolling: touch;
-  transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-overflow-scrolling: touch;
+}
+
+.overflow-y-auto::-webkit-scrollbar-button,
+.overflow-x-auto::-webkit-scrollbar-button,
+.overflow-auto::-webkit-scrollbar-button,
+.scrollbar-thin::-webkit-scrollbar-button {
+    display: none;
+    height: 0;
+    width: 0;
 }
 
 .overflow-x-auto::-webkit-scrollbar {
-  height: 8px;
+    height: 6px;
 }
 
 .overflow-y-auto::-webkit-scrollbar,
-.overflow-x-auto::-webkit-scrollbar {
-  -webkit-appearance: none;
-  width: 8px;
-  background-color: rgb(var(--muted) / 0.5) !important;
-  border-radius: 6px;
+.overflow-x-auto::-webkit-scrollbar,
+.overflow-auto::-webkit-scrollbar,
+.scrollbar-thin::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 6px;
+    background: transparent;
+}
+
+.overflow-y-auto::-webkit-scrollbar-track,
+.overflow-x-auto::-webkit-scrollbar-track,
+.overflow-auto::-webkit-scrollbar-track,
+.scrollbar-thin::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb,
-.overflow-x-auto::-webkit-scrollbar-thumb {
-  background-color: rgb(var(--primary) / 0.3) !important;
-  border-radius: 6px;
-  border: 2px solid transparent;
-  background-clip: padding-box;
-  visibility: visible !important;
-  opacity: 1 !important;
-  min-height: 20px !important;
-  height: 20px !important;
-  width: 4px !important;
+.overflow-x-auto::-webkit-scrollbar-thumb,
+.overflow-auto::-webkit-scrollbar-thumb,
+.scrollbar-thin::-webkit-scrollbar-thumb {
+    background-color: rgb(var(--primary) / 0.3);
+    border-radius: 3px;
+}
+
+.overflow-y-auto::-webkit-scrollbar-thumb:hover,
+.overflow-x-auto::-webkit-scrollbar-thumb:hover,
+.overflow-auto::-webkit-scrollbar-thumb:hover,
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(var(--primary) / 0.5);
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
That one was a little harder. My detail knowledge about CSS is a little limited so that one is much more done with Claude. Fell free to merge, adjust, send back or recect this PR.

## Problem

Scrollbars were visually inconsistent across browsers:

- **Chrome/Edge:** no styled scrollbar on most scrollable containers — the OS-standard scrollbar was shown instead of the app-styled one.
- **Firefox:** `scrollbar-width: auto !important` in `globals.css` overrode `hide-scrollbar`'s `scrollbar-width: none`, causing scrollbars to appear where they were explicitly hidden.
- **KanbanCardDetail modal:** both scroll panes were not scrollable in Firefox/Edge after a previous change introduced a wrapper div around children.

## Root cause

Chrome 121+ changed behaviour: if `scrollbar-width` is set on an element, Chrome ignores all `::-webkit-scrollbar` pseudo-element rules and uses the standard API instead, falling back to the native OS scrollbar on Windows.

The existing `globals.css` set `scrollbar-width: auto !important` without a browser guard, which broke the webkit-styled scrollbars in Chromium. The same effect was triggered by `tailwind-scrollbar` plugin classes (`scrollbar-thin`, `scrollbar-thumb-*` etc.) — these also set `scrollbar-width` on the element.

For `KanbanCardDetail`: `Modal.tsx` wraps children in a bare `<div className="">` for `size="default"`, which broke the flex height chain needed by the two-pane layout.

## Changes

**`globals.css`**
- Moved `scrollbar-width: thin` + `scrollbar-color` inside `@supports (-moz-appearance: none)` (Firefox-only guard), so Firefox gets styled scrollbars without triggering Chrome's standard-API path.
- Rewrote the `::-webkit-scrollbar` block to cover `.overflow-y-auto`, `.overflow-x-auto`, `.overflow-auto`, and `.scrollbar-thin` consistently — 6 px width, `primary/0.3` thumb, transparent track, no scrollbar buttons.
- Removed the old `scrollbar-width: auto !important` rule that was breaking `hide-scrollbar` in Firefox.

**`KanbanCardDetail.tsx`**
- Switched to `size="fullscreen"` on `<Modal>` — this wraps children in `flex-1 overflow-auto` instead of a bare div, restoring the flex chain.
- Inner container uses `min-h-full` (not `flex-1`) since the fullscreen wrapper is not itself a flex container.
- Both scroll panes use `overflow-y-auto` without the `lg:` responsive prefix — the `globals.css` webkit rules target `.overflow-y-auto` exactly; the responsive variant `.lg\:overflow-y-auto` is a different class name and would not match.

**`ChecklistHome.tsx` / `NotesHome.tsx`**
- Removed `hide-scrollbar` from main containers. With the corrected global scrollbar styling, hidden scrollbars on these containers caused visual inconsistency with the rest of the app where scrollbars are now consistently visible and styled.

**`SidebarWrapper.tsx` / `Kanban.tsx`**
- Removed `tailwind-scrollbar` plugin classes (`scrollbar-thin`, `scrollbar-thumb-*`, `scrollbar-track-*`, `scrollbar-*-rounded-md`). These set `scrollbar-width` on the element, which triggers Chrome 121+'s standard-API path and causes the webkit rules in `globals.css` to be ignored. The global styles already cover `.overflow-y-auto` and `.overflow-auto`, so the plugin classes are redundant.

## Minor visual change: KanbanCardDetail modal header

Using `size="fullscreen"` changes the modal header from `p-6` padding + `mb-6` separator to `p-3 border-b` — a tighter, more compact look. This is a side effect of the existing `fullscreen` variant in `Modal.tsx` and is intentional in this PR; happy to address the original header style separately if preferred.

## Tested

- **Chrome / Edge (Chromium):** scrollbars visible, styled, no layout regressions in Sidebar, Kanban board, KanbanCardDetail (both panes), ChecklistHome, NotesHome.
- **Firefox:** scrollbars styled and thin via `@supports` guard; `hide-scrollbar` works again where used.