### PR TITLE
fix(checklist): respect drop position when reordering subitems

### DIFF
--- a/app/_hooks/useChecklist.tsx
+++ b/app/_hooks/useChecklist.tsx
@@ -508,7 +508,7 @@ export const useChecklist = ({
           activeInfo.index < overInfo.index;
 
         const position = isDropIndicator
-          ? overId.startsWith("drop-after::")
+          ? overId.startsWith("drop-after")
             ? "after"
             : "before"
           : isDraggingDown
@@ -539,7 +539,7 @@ export const useChecklist = ({
       activeInfo.index < overInfo.index;
 
     const reorderPosition = isDropIndicator
-      ? overId.startsWith("drop-after::")
+      ? overId.startsWith("drop-after")
         ? "after"
         : "before"
       : isDraggingDown


### PR DESCRIPTION
## Summary

Dragging a subitem and dropping it between two siblings always inserted
it at the top of the parent's children list, ignoring the drop position.
Top-level reordering was unaffected.

## Steps to reproduce

1. Create a checklist item `A` with subitems `A1`, `A2`, `A3`.
2. Drag `A3` and drop it between `A1` and `A2`.
3. Expected order: `A1, A3, A2`. Actual order: `A3, A1, A2`.

Reproduces on `develop` in Firefox, Edge and Brave.

## Root cause

`handleDragEnd` in `app/_hooks/useChecklist.tsx` decides whether to drop
before or after the target by matching the drop-zone id prefix
`"drop-after::"`. Top-level drop indicators use that prefix, but subitem
drop indicators use `"drop-after-child::"` (see `NestedChecklistItem.tsx`).

`"drop-after-child::…".startsWith("drop-after::")` is `false`, so the
check never matched for subitems and `position` always fell back to
`"before"` — inserting the dragged item before the target instead of
after it.

The same check is used both for the optimistic local update and for the
`position` value sent to the `reorderItems` server action, so the wrong
result was consistent and persisted to disk.

## Fix

Match the prefix `"drop-after"` (without the trailing `::`) at both call
sites, so it matches `drop-after::` and `drop-after-child::` alike. This
mirrors the `isDropIndicator` check a few lines above, which already uses
the `"drop-after"` / `"drop-before"` prefixes. `drop-before` /
`drop-before-child` indicators still correctly fall through to `"before"`.

Two-line change, no other files. The server action was already correct —
it just consumes the `position` it receives.

## Tests done

- [x] Subitem `A3` dropped between `A1` and `A2` → `A1, A3, A2`
- [x] Subitem dropped after the last sibling → lands last
- [x] Subitem dropped before the first sibling → lands first
- [x] Top-level reorder still works (drop before/after top-level items)
- [x] Reload the page — the new order persists