### PR TITLE
fix: ensure unique item IDs when importing checklists (#501)

### DIFF
--- a/app/_utils/client-parser-utils.ts
+++ b/app/_utils/client-parser-utils.ts
@@ -42,6 +42,10 @@ export const parseChecklistContent = (
     (line) => line.trim().startsWith("- [") || /^\s*- \[/.test(line),
   );
 
+  let globalItemCounter = 0;
+  const generateItemId = (level: number): string =>
+    `${id}-${level}-${globalItemCounter++}`;
+
   const buildNestedItems = (
     lines: string[],
     startIndex: number = 0,
@@ -164,7 +168,7 @@ export const parseChecklistContent = (
           });
 
           item = {
-            id: (itemMetadata.id as string) || `${id}-${currentItemIndex}`,
+            id: (itemMetadata.id as string) || generateItemId(parentLevel),
             text: itemText,
             completed,
             order: currentItemIndex,
@@ -206,7 +210,7 @@ export const parseChecklistContent = (
           }
 
           item = {
-            id: itemMetadata.id || `${id}-${currentItemIndex}`,
+            id: itemMetadata.id || generateItemId(parentLevel),
             text: itemText,
             completed,
             order: currentItemIndex,
@@ -245,6 +249,21 @@ export const parseChecklistContent = (
   };
 
   const { items } = buildNestedItems(itemLines, 0, 0, 0);
+
+  const dedupeItemIds = (itemList: Item[], seen: Set<string>): void => {
+    itemList.forEach((item) => {
+      if (item.id && seen.has(item.id)) {
+        item.id = generateItemId(0);
+      }
+      if (item.id) {
+        seen.add(item.id);
+      }
+      if (item.children && item.children.length > 0) {
+        dedupeItemIds(item.children, seen);
+      }
+    });
+  };
+  dedupeItemIds(items, new Set<string>());
 
   let statuses = undefined;
   if (metadata.statuses && Array.isArray(metadata.statuses)) {

--- a/tests/utils/client-parser-utils.test.ts
+++ b/tests/utils/client-parser-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { parseChecklistContent } from "@/app/_utils/client-parser-utils";
+import { Item } from "@/app/_types";
+
+const collectIds = (items: Item[], acc: string[] = []): string[] => {
+  items.forEach((item) => {
+    acc.push(item.id);
+    if (item.children && item.children.length > 0) {
+      collectIds(item.children, acc);
+    }
+  });
+  return acc;
+};
+
+describe("parseChecklistContent — unique item IDs", () => {
+  it("assigns unique IDs to every item across nested groups (regression for #501)", () => {
+    const lines: string[] = [];
+    for (let g = 1; g <= 4; g++) {
+      lines.push(`- [ ] Group ${g}`);
+      for (let i = 1; i <= 5; i++) {
+        lines.push(`  - [ ] Item ${g}.${i}`);
+      }
+    }
+    const content = lines.join("\n");
+
+    const { items } = parseChecklistContent(content, "my-list");
+    const ids = collectIds(items);
+
+    expect(ids).toHaveLength(4 + 4 * 5);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("preserves IDs stored in inline item metadata", () => {
+    const content = [
+      "- [ ] Item with stored id | metadata:{\"id\":\"stored-id-1\"}",
+      "- [ ] Item without stored id",
+    ].join("\n");
+
+    const { items } = parseChecklistContent(content, "my-list");
+
+    expect(items[0].id).toBe("stored-id-1");
+    expect(items[1].id).not.toBe("stored-id-1");
+    expect(items[1].id).toBeTruthy();
+  });
+
+  it("dedupes IDs from already-broken imported files", () => {
+    const content = [
+      "- [ ] Group A | metadata:{\"id\":\"file-0\"}",
+      "  - [ ] Item A1 | metadata:{\"id\":\"file-0\"}",
+      "  - [ ] Item A2 | metadata:{\"id\":\"file-1\"}",
+      "- [ ] Group B | metadata:{\"id\":\"file-1\"}",
+      "  - [ ] Item B1 | metadata:{\"id\":\"file-2\"}",
+    ].join("\n");
+
+    const { items } = parseChecklistContent(content, "file");
+    const ids = collectIds(items);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(items[0].id).toBe("file-0");
+    expect(items[0].children?.[0].id).not.toBe("file-0");
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #501. When a checklist is imported via file-drop (without per-item
metadata), several items get identical IDs. Since checkbox toggling is keyed on
the item ID, checking one box toggles every item that shares that ID — e.g.
clicking "Item D1" also toggled Group A, Item A1, B1 and C1.

## Root cause

Two markdown parsers assign item IDs:

- `app/_utils/checklist-utils.ts` (`parseMarkdown`) generates
  `${id}-${level}-${counter}` with a global counter → unique.
- `app/_utils/client-parser-utils.ts` (`parseChecklistContent` →
  `buildNestedItems`) generated `${id}-${currentItemIndex}` with **no** level
  segment and reset the index to `0` for each nested group. Group headers and
  child items therefore shared the same number space and collided
  (`<file>-0` appeared 5× in the repro).

The IDs that actually get persisted on file-drop come from the client parser,
so the earlier server-side change in #509 didn't cover this path.

## Fix (`client-parser-utils.ts`)

- Replace the per-group index fallback with a monotonic `generateItemId(level)`
  (`${id}-${level}-${globalCounter++}`), matching the scheme already used by the
  server parser. Guarantees uniqueness regardless of nesting.
- IDs stored in inline item metadata are still preserved (backward compatible).
- Add a post-parse dedupe pass: if duplicate IDs remain (e.g. from files
  imported before this fix), the first occurrence is kept and later duplicates
  get a fresh unique ID. Already-broken checklists self-heal on the next save.

## Tests

Added `tests/utils/client-parser-utils.test.ts`:
- unique IDs across 4 groups × 5 nested items (regression for #501)
- stored inline metadata IDs are preserved
- duplicate IDs from already-broken files are deduped

`yarn lint`, `tsc --noEmit` and `yarn test:run` all pass.