### PR TITLE
Add proxyClientMaxBodySize to next.config.mjs to fix bodySizeLimit bug

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,17 +3,19 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
+const maxBodySize = "1gb";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   serverExternalPackages: ["ws", "libsodium-wrappers-sumo"],
-  serverActions: {
-    bodySizeLimit: "100mb",
-  },
   experimental: {
+    // https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions
     serverActions: {
-      bodySizeLimit: "100mb",
+      bodySizeLimit: maxBodySize,
     },
+    // https://nextjs.org/docs/app/api-reference/config/next-config-js/proxyClientMaxBodySize
+    proxyClientMaxBodySize: maxBodySize,
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
Hey, I think I've fixed this issue...

Following the error messages when uploading large files (the specific error message linked to something about proxy middleware), I found [proxyClientMaxBodySize](https://nextjs.org/docs/app/api-reference/config/next-config-js/proxyClientMaxBodySize) in the docs.. I tried it and it seems to do the trick.  `bodySizeLimit` and `proxyClientMaxBodySize` both seem to need to be set.

Be sure to set Settings > App preferences > Maximum file upload size as well.

I tested this on `main` and `develop` in dev mode with some large files, <s>but not sure how to go about testing a built version, inside a docker container, etc.  I see some steps [here](https://github.com/fccview/jotty/blob/main/.github/workflows/prebuild-release.yml#L26-L29) and [here](https://github.com/fccview/jotty/blob/main/.github/workflows/prebuild-release.yml#L39-L46) for a production build of Next.js standalone, but would appreciate any pointers on your workflow to build and test the docker container locally.</s>

1. I ran `yarn build`.
2. I changed [this line](https://github.com/fccview/jotty/blob/main/docker-compose.yml#L6) to `build: .` 
3. I commented [these lines](https://github.com/fccview/jotty/blob/main/Dockerfile#L54-L56) about patches
4. I commented [these lines](https://github.com/fccview/jotty/blob/main/docker-entrypoint.sh#L11-L13) about patches
5. and ran `docker-compose up -d`
 
I'm able to upload 150MB and 250MB files there too.

Cheers! 