### PR TITLE
Do not translate "Markdown".

### DIFF
--- a/app/_translations/zh.json
+++ b/app/_translations/zh.json
@@ -409,7 +409,7 @@
     "tags": "标签",
     "noTagsFound": "未找到标签",
     "searchTags": "搜索标签...",
-    "copyRawContent": "复制降价",
+    "copyRawContent": "复制 Markdown",
     "printSaveAsPdf": "打印 / 另存为PDF",
     "tableOfContents": "目录",
     "wordCount": "{count, plural, one {# 个字} other {# 个字}}",


### PR DESCRIPTION
In Chinese, Markdown is generally not translated as "price reduction" (literally "lowering the price").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Chinese translation for the “copy raw content” label to show “复制 Markdown” for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->