### PR TITLE
fix: authenticate protected PWA manifest requests

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -100,7 +100,6 @@ export const generateMetadata = async (): Promise<Metadata> => {
   return {
     title: appName,
     description: appDescription,
-    manifest: "/api/manifest",
     icons: {
       icon: [
         {
@@ -235,6 +234,11 @@ export default async function RootLayout({
     >
       <head>
         {process.env.NODE_ENV === "development" && <SuppressWarnings />}
+        <link
+          rel="manifest"
+          href="/api/manifest"
+          crossOrigin="use-credentials"
+        />
         <link rel="icon" href="/app-icons/favicon.ico" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />


### PR DESCRIPTION
## Why this change is needed

Jotty can be deployed behind an authentication reverse proxy that protects every application path, including the web app manifest.

In this setup, a browser may create a normal home-screen shortcut instead of offering to install Jotty as a PWA.

The browser requests Jotty's app manifest without the existing login credentials. The authentication proxy redirects that request to its login page, so the browser cannot recognize Jotty as an installable app.

## What this changes

This change tells the browser to include the existing login credentials when it requests `/api/manifest`.

For normal Jotty installations, the manifest URL and behavior stay the same. For installations protected by an authentication reverse proxy, the browser can now read the manifest and offer the proper PWA installation instead of only creating a shortcut.

## Type of change (pick one or more if needed)

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Please check the following:

- [x] **Branching:** I branched out of `develop` and I am targeting `develop` for this PR. (Code directed to `main` will be closed).
- [x] **AI Code:** If I used AI, I have cleaned up the code, removed bloat, and verified logic.
- [x] **Translations:** I have used translation keys. I have not included any hardcoded strings (see `howto/TRANSLATIONS.md`).
- [x] **Components:** I used pre-existing components from `app/_components/GlobalComponents/` or `FeatureComponents/` instead of creating duplicates.
- [x] **Styling:** I have kept styling consistent and avoided inline styles.
- [x] **Self-Review:** I have performed a self-review of my code.

## Validation

- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test:run tests/security --reporter=verbose` (39 tests)
- `yarn test:run tests/api --reporter=verbose` (141 tests)
- `yarn test:run tests/server-actions --reporter=verbose` (459 tests)
- `yarn build`
- Tested with a production container and confirmed that the manifest is valid and the generated link includes `crossorigin="use-credentials"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web app manifest loading by adding a document-level manifest link with credential support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->