### PR TITLE
feat: use the notes rich-text editor for task descriptions

### DIFF
--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -470,6 +470,7 @@ export const KanbanCardDetail = ({
                 <UnifiedMarkdownRenderer
                   content={descriptionMarkdown}
                   className="text-card-foreground prose-sm max-w-none leading-relaxed"
+                  showStats={false}
                 />
               ) : (
                 <p className="text-muted-foreground text-sm opacity-50">

--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -15,7 +15,6 @@ import { createNotificationForUser } from "@/app/_server/actions/notifications";
 import { usersWithAccess } from "@/app/_server/actions/share/queries";
 import { getUsers } from "@/app/_server/actions/users";
 import { FloppyDiskIcon, MultiplicationSignIcon, ArrowDown01Icon, ArrowRight01Icon } from "hugeicons-react";
-import { convertMarkdownToHtml } from "@/app/_utils/markdown-utils";
 import { usePermissions } from "@/app/_providers/PermissionsProvider";
 import { usePreferredDateTime } from "@/app/_hooks/usePreferredDateTime";
 import { useTranslations } from "next-intl";
@@ -25,6 +24,8 @@ import { KanbanCardDetailSubtasks } from "./KanbanCardDetailSubtasks";
 import { KanbanItemTimer } from "./KanbanItemTimer";
 import { TimeEntriesAccordion } from "./TimeEntriesAccordion";
 import { TimeEntriesModal } from "./TimeEntriesModal";
+import { TaskDescriptionEditor } from "./TaskDescriptionEditor";
+import { UnifiedMarkdownRenderer } from "@/app/_components/FeatureComponents/Notes/Parts/UnifiedMarkdownRenderer";
 import { useKanbanItem } from "@/app/_hooks/kanban/useKanbanItem";
 import { useAppMode } from "@/app/_providers/AppModeProvider";
 import { formatTimerTime } from "@/app/_utils/kanban/index";
@@ -152,12 +153,10 @@ export const KanbanCardDetail = ({
     _loadUsers();
   }, [isOpen, checklistUuid, checklist.owner]);
 
-  const descriptionHtml = useMemo(() => {
-    const noDescText = `<p class="text-muted-foreground text-sm opacity-50">${t("checklists.noDescription")}</p>`;
-    if (!item.description) return noDescText;
-    const unsanitized = _unsanitizeDescription(item.description);
-    return convertMarkdownToHtml(unsanitized.replace(/\n/g, "  \n")) || noDescText;
-  }, [item.description, t]);
+  const descriptionMarkdown = useMemo(() => {
+    if (!item.description) return "";
+    return _unsanitizeDescription(item.description);
+  }, [item.description]);
 
   const _saveField = async (fields: Record<string, string>) => {
     const formData = new FormData();
@@ -446,15 +445,9 @@ export const KanbanCardDetail = ({
                 <label className="block text-sm font-medium text-foreground mb-2">
                   {t("common.description")}
                 </label>
-                <textarea
-                  value={editDescription}
-                  onChange={(e) => setEditDescription(e.target.value)}
-                  className="w-full px-3 py-2 bg-background border border-input rounded-jotty focus:outline-none focus:border-ring transition-all min-h-[120px] text-base resize-y"
-                  placeholder={t("checklists.addDescriptionOptional")}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && e.ctrlKey) { e.preventDefault(); handleSave(); }
-                    else if (e.key === "Escape") { e.preventDefault(); setEditText(item.text); setEditDescription(_unsanitizeDescription(item.description || "")); setIsEditing(false); }
-                  }}
+                <TaskDescriptionEditor
+                  content={editDescription}
+                  onContentChange={setEditDescription}
                 />
               </div>
               <div className="flex justify-end gap-2">
@@ -473,10 +466,16 @@ export const KanbanCardDetail = ({
               className={`bg-card border border-border rounded-jotty p-4 shadow-sm ${permissions?.canEdit ? "cursor-pointer" : ""}`}
               onClick={() => permissions?.canEdit && setIsEditing(true)}
             >
-              <div
-                className="text-card-foreground prose prose-sm dark:prose-invert max-w-none leading-relaxed"
-                dangerouslySetInnerHTML={{ __html: descriptionHtml }}
-              />
+              {descriptionMarkdown ? (
+                <UnifiedMarkdownRenderer
+                  content={descriptionMarkdown}
+                  className="text-card-foreground prose-sm max-w-none leading-relaxed"
+                />
+              ) : (
+                <p className="text-muted-foreground text-sm opacity-50">
+                  {t("checklists.noDescription")}
+                </p>
+              )}
             </div>
           )}
 

--- a/app/_components/FeatureComponents/Kanban/TaskDescriptionEditor.tsx
+++ b/app/_components/FeatureComponents/Kanban/TaskDescriptionEditor.tsx
@@ -5,10 +5,10 @@ import {
   TiptapEditor,
   TiptapEditorRef,
 } from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/TipTapEditor";
-import { MinimalModeEditor } from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalModeEditor";
+import { MinimalEditorPanel } from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalEditorPanel";
 import { convertHtmlToMarkdownUnified } from "@/app/_utils/markdown-utils";
 import { useAppMode } from "@/app/_providers/AppModeProvider";
-import { useSettings } from "@/app/_utils/settings-store";
+import { useMinimalMode } from "@/app/_hooks/useMinimalMode";
 
 interface TaskDescriptionEditorProps {
   /** Current description content (markdown text, already unsanitized). */
@@ -28,10 +28,8 @@ export const TaskDescriptionEditor = ({
   onContentChange,
 }: TaskDescriptionEditorProps) => {
   const { user, notes, checklists } = useAppMode();
-  const { compactMode } = useSettings();
   const editorRef = useRef<TiptapEditorRef>(null);
-
-  const isMinimalMode = user?.disableRichEditor === "enable";
+  const isMinimalMode = useMinimalMode();
 
   useEffect(() => {
     if (!isMinimalMode && editorRef.current) {
@@ -58,16 +56,16 @@ export const TaskDescriptionEditor = ({
 
   if (isMinimalMode) {
     return (
-      <div className="h-[40vh] min-h-[200px] lg:h-[48vh]">
-        <MinimalModeEditor
-          isEditing
-          noteContent={content}
-          onEditorContentChange={(next, isMarkdown) =>
-            handleEditorContentChange(next, isMarkdown)
-          }
-          compactMode={compactMode}
-        />
-      </div>
+      <MinimalEditorPanel
+        isEditing
+        noteContent={content}
+        onEditorContentChange={(next, isMarkdown) =>
+          handleEditorContentChange(next, isMarkdown)
+        }
+        renderWrapper={(children) => (
+          <div className="h-[40vh] min-h-[200px] lg:h-[48vh]">{children}</div>
+        )}
+      />
     );
   }
 

--- a/app/_components/FeatureComponents/Kanban/TaskDescriptionEditor.tsx
+++ b/app/_components/FeatureComponents/Kanban/TaskDescriptionEditor.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  TiptapEditor,
+  TiptapEditorRef,
+} from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/TipTapEditor";
+import { MinimalModeEditor } from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalModeEditor";
+import { convertHtmlToMarkdownUnified } from "@/app/_utils/markdown-utils";
+import { useAppMode } from "@/app/_providers/AppModeProvider";
+import { useSettings } from "@/app/_utils/settings-store";
+
+interface TaskDescriptionEditorProps {
+  /** Current description content (markdown text, already unsanitized). */
+  content: string;
+  /** Called with the latest markdown content whenever the editor changes. */
+  onContentChange: (markdownContent: string) => void;
+}
+
+/**
+ * Renders the task description editor surface, reusing the same editor
+ * stack as notes (Tiptap rich editor, or the minimal-mode editor when the
+ * user has disabled the rich editor). Emits markdown text via onContentChange
+ * so callers can persist it in the existing checklist description format.
+ */
+export const TaskDescriptionEditor = ({
+  content,
+  onContentChange,
+}: TaskDescriptionEditorProps) => {
+  const { user, notes, checklists } = useAppMode();
+  const { compactMode } = useSettings();
+  const editorRef = useRef<TiptapEditorRef>(null);
+
+  const isMinimalMode = user?.disableRichEditor === "enable";
+
+  useEffect(() => {
+    if (!isMinimalMode && editorRef.current) {
+      editorRef.current.updateAtMentionData(
+        notes,
+        checklists,
+        user?.username || "",
+      );
+    }
+  }, [notes, checklists, user?.username, isMinimalMode]);
+
+  const handleEditorContentChange = (
+    next: string,
+    isMarkdownMode: boolean,
+  ) => {
+    if (isMarkdownMode) {
+      onContentChange(next);
+      return;
+    }
+    // Visual mode emits HTML; normalise back to markdown for storage.
+    const html = next.trim().startsWith("<") ? next : `<p>${next}</p>`;
+    onContentChange(convertHtmlToMarkdownUnified(html, user?.tableSyntax));
+  };
+
+  if (isMinimalMode) {
+    return (
+      <div className="h-[40vh] min-h-[200px] lg:h-[48vh]">
+        <MinimalModeEditor
+          isEditing
+          noteContent={content}
+          onEditorContentChange={(next, isMarkdown) =>
+            handleEditorContentChange(next, isMarkdown)
+          }
+          compactMode={compactMode}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[40vh] min-h-[200px] lg:h-[48vh] border border-input rounded-jotty overflow-hidden">
+      <TiptapEditor
+        ref={editorRef}
+        content={content}
+        onChange={(next, isMarkdownMode) =>
+          handleEditorContentChange(next, isMarkdownMode)
+        }
+        tableSyntax={user?.tableSyntax}
+        notes={notes}
+        checklists={checklists}
+      />
+    </div>
+  );
+};

--- a/app/_components/FeatureComponents/Notes/Parts/NoteEditor/NoteEditorContent.tsx
+++ b/app/_components/FeatureComponents/Notes/Parts/NoteEditor/NoteEditorContent.tsx
@@ -11,7 +11,8 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useMemo } from "react";
 import { getReferences } from "@/app/_utils/indexes-utils";
 import { usePermissions } from "@/app/_providers/PermissionsProvider";
-import { MinimalModeEditor } from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalModeEditor";
+import { MinimalEditorPanel } from "@/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalEditorPanel";
+import { useMinimalMode } from "@/app/_hooks/useMinimalMode";
 import { LockKeyIcon, ViewIcon, SquareUnlock01Icon } from "hugeicons-react";
 import { Button } from "@/app/_components/GlobalComponents/Buttons/Button";
 import {
@@ -56,8 +57,7 @@ export const NoteEditorContent = ({
   const editor = searchParams?.get("editor");
   const editorRef = useRef<TiptapEditorRef>(null);
   const { permissions } = usePermissions();
-
-  const isMinimalMode = user?.disableRichEditor === "enable";
+  const isMinimalMode = useMinimalMode();
 
   const referencingItems = useMemo(() => {
     return getReferences(linkIndex, noteId, ItemTypes.NOTE, notes, checklists);
@@ -141,14 +141,11 @@ export const NoteEditorContent = ({
 
   if (isMinimalMode) {
     return (
-      <div className="flex-1 h-full pb-10 lg:pb-0">
-        <MinimalModeEditor
-          isEditing={isEditMode ?? false}
-          noteContent={encrypted ? editorContent : noteContent || ""}
-          onEditorContentChange={onEditorContentChange}
-          compactMode={compactMode}
-        />
-      </div>
+      <MinimalEditorPanel
+        isEditing={isEditMode ?? false}
+        noteContent={encrypted ? editorContent : noteContent || ""}
+        onEditorContentChange={onEditorContentChange}
+      />
     );
   }
 

--- a/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalEditorPanel.tsx
+++ b/app/_components/FeatureComponents/Notes/Parts/TipTap/MinimalEditorPanel.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ReactNode } from "react";
+import { MinimalModeEditor } from "./MinimalModeEditor";
+import { useSettings } from "@/app/_utils/settings-store";
+
+interface MinimalEditorPanelProps {
+  /** Whether the editor should be in editing (vs. read-only view) mode. */
+  isEditing: boolean;
+  /** Content rendered inside the minimal editor. */
+  noteContent: string;
+  /** Forwarded to MinimalModeEditor; signature matches its own. */
+  onEditorContentChange: (
+    content: string,
+    isMarkdown: boolean,
+    isDirty: boolean,
+  ) => void;
+  /**
+   * Wrapper class for the minimal-mode surface. Defaults to a full-height
+   * flex container matching the notes editor layout; callers with a bespoke
+   * container (e.g. the task description editor) can pass their own.
+   */
+  className?: string;
+  /**
+   * When provided, this node replaces the default wrapper div entirely and
+   * receives the MinimalModeEditor as its child — used by callers that need a
+   * fully custom container (border, rounded corners, fixed height, etc.).
+   */
+  renderWrapper?: (children: ReactNode) => ReactNode;
+}
+
+/**
+ * Renders the minimal (markdown-only) editor surface. Pair with the
+ * `useMinimalMode` hook to decide whether to render this panel or fall through
+ * to the rich (Tiptap) editor. Centralises the repeated
+ * `<MinimalModeEditor .../>` wiring (props + compactMode lookup) that
+ * previously was duplicated across the note editor and the task description
+ * editor.
+ */
+export const MinimalEditorPanel = ({
+  isEditing,
+  noteContent,
+  onEditorContentChange,
+  className = "flex-1 h-full pb-10 lg:pb-0",
+  renderWrapper,
+}: MinimalEditorPanelProps) => {
+  const { compactMode } = useSettings();
+
+  const editor = (
+    <MinimalModeEditor
+      isEditing={isEditing}
+      noteContent={noteContent}
+      onEditorContentChange={onEditorContentChange}
+      compactMode={compactMode}
+    />
+  );
+
+  return (
+    <>
+      {renderWrapper ? renderWrapper(editor) : <div className={className}>{editor}</div>}
+    </>
+  );
+};

--- a/app/_components/FeatureComponents/Notes/Parts/TipTap/Toolbar/ToolbarDropdown.tsx
+++ b/app/_components/FeatureComponents/Notes/Parts/TipTap/Toolbar/ToolbarDropdown.tsx
@@ -28,7 +28,9 @@ export const ToolbarDropdown = ({
       portalRoot.style.position = "fixed";
       portalRoot.style.top = "0";
       portalRoot.style.left = "0";
-      portalRoot.style.zIndex = "10";
+      // Stack above the modal portal root (z-index 9999) so dropdowns
+      // render on top of modal overlays when the editor is used inside a modal.
+      portalRoot.style.zIndex = "10000";
       portalRoot.style.pointerEvents = "none";
       document.body.appendChild(portalRoot);
     }

--- a/app/_components/FeatureComponents/Notes/Parts/UnifiedMarkdownRenderer.tsx
+++ b/app/_components/FeatureComponents/Notes/Parts/UnifiedMarkdownRenderer.tsx
@@ -57,12 +57,15 @@ interface UnifiedMarkdownRendererProps {
   content: string;
   className?: string;
   forceLightMode?: boolean;
+  /** Whether to render the word/char/reading-time footer stats. Defaults to true. */
+  showStats?: boolean;
 }
 
 export const UnifiedMarkdownRenderer = ({
   content,
   className = "",
   forceLightMode = false,
+  showStats = true,
 }: UnifiedMarkdownRendererProps) => {
   const [isClient, setIsClient] = useState(false);
   const [selectedQuote, setSelectedQuote] = useState<string | null>(null);
@@ -569,7 +572,7 @@ export const UnifiedMarkdownRenderer = ({
           {processedContent}
         </ReactMarkdown>
       </div>
-      <NoteFooterStats content={content} />
+      {showStats && <NoteFooterStats content={content} />}
     </>
   );
 };

--- a/app/_components/GlobalComponents/Modals/Modal.tsx
+++ b/app/_components/GlobalComponents/Modals/Modal.tsx
@@ -56,6 +56,18 @@ export const Modal = ({
         modalRef.current &&
         !modalRef.current.contains(event.target as Node)
       ) {
+        // Don't dismiss the modal when interacting with editor toolbar
+        // dropdowns that are portaled to their own root but belong to editor
+        // UI rendered inside this modal.
+        const toolbarDropdownPortal = document.getElementById(
+          "toolbar-dropdown-portal-root",
+        );
+        if (
+          toolbarDropdownPortal &&
+          toolbarDropdownPortal.contains(event.target as Node)
+        ) {
+          return;
+        }
         onClose();
       }
     }

--- a/app/_hooks/useMinimalMode.ts
+++ b/app/_hooks/useMinimalMode.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useAppMode } from "@/app/_providers/AppModeProvider";
+
+/**
+ * Whether the current user has disabled the rich (Tiptap) editor in favour of
+ * the lightweight markdown-only editor. Derives the same flag that previously
+ * was inlined as `user?.disableRichEditor === "enable"` across several
+ * components, so the minimal-mode branch can be selected consistently.
+ */
+export const useMinimalMode = (): boolean => {
+  const { user } = useAppMode();
+  return user?.disableRichEditor === "enable";
+};

--- a/app/_hooks/useNoteEditor.tsx
+++ b/app/_hooks/useNoteEditor.tsx
@@ -17,6 +17,7 @@ import { itemHref, publicHref } from "@/app/_utils/global-utils";
 import { Note } from "@/app/_types";
 import { useAppMode } from "@/app/_providers/AppModeProvider";
 import { useToast } from "@/app/_providers/ToastProvider";
+import { useMinimalMode } from "@/app/_hooks/useMinimalMode";
 import { ItemTypes } from "@/app/_types/enums";
 import { extractYamlMetadata } from "@/app/_utils/yaml-metadata-utils";
 import { ConfirmModal } from "@/app/_components/GlobalComponents/Modals/ConfirmationModals/ConfirmModal";
@@ -39,7 +40,7 @@ export const useNoteEditor = ({
   const router = useRouter();
   const { user } = useAppMode();
   const { showToast } = useToast();
-  const isMinimalMode = user?.disableRichEditor === "enable";
+  const isMinimalMode = useMinimalMode();
   const defaultEditorIsMarkdown = user?.notesDefaultEditor === "markdown";
   const [title, setTitle] = useState(note.title);
   const [category, setCategory] = useState(note.category || "Uncategorized");


### PR DESCRIPTION
Reuses the Tiptap notes editor for task/checklist item descriptions in the Kanban card detail modal (which was previously just a plain textarea). Adds a `TaskDescriptionEditor` wrapper that emits markdown for the existing storage format, switches the read-only view to `UnifiedMarkdownRenderer` (with a new `showStats` opt-out to hide the word/char/reading-time footer), and fixes two modal/editor integration issues so the toolbar dropdowns (code, diagrams, extra items) actually work inside a modal: it raises the dropdown portal z-index above the modal overlay and stops the modal from closing when interacting with a dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rich-text and Markdown editing options for task descriptions.
  * Improved read-only task description rendering.
  * Added the option to hide footer statistics when displaying formatted content.
  * Improved consistency between lightweight Markdown and rich-text editing modes.

* **Bug Fixes**
  * Prevented editor toolbar dropdowns from appearing behind modal overlays.
  * Fixed toolbar interactions that could unintentionally close open modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->