### PR TITLE
Add schema for notes singleton

### DIFF
--- a/public/api/paths/notes.yaml
+++ b/public/api/paths/notes.yaml
@@ -114,7 +114,7 @@
     description: Retrieves a single note by id
     tags:
       - Notes
-    paramaters:
+    parameters:
       - name: noteId
         in: path
         required: true

--- a/public/api/paths/notes.yaml
+++ b/public/api/paths/notes.yaml
@@ -109,6 +109,54 @@
         description: Invalid request (missing title)
 
 /notes/{noteId}:
+  get:
+    summary: Get Note by id
+    description: Retrieves a single note by id
+    tags:
+      - Notes
+    paramaters:
+      - name: noteId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: UUID of the note
+    responses:
+      '200':
+        description: Note retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                success:
+                  type: boolean
+                  example: true
+                data:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    title:
+                      type: string
+                    content:
+                      type: string
+                    category:
+                      type: string
+                    createdAt:
+                      type: string
+                      format: date-time
+                    updatedAt:
+                      type: string
+                      format: date-time
+                    owner:
+                      type: string
+      '404':
+        description: Note not found
+      '400':
+        description: Invalid request
   put:
     summary: Update Note
     description: Updates an existing note. All fields are optional - unspecified fields will preserve their current values.


### PR DESCRIPTION
Doesn't appear in the docs, but exists on the API. 

I don't know if it's deliberate, or whether these schemas are generated, but caught me out!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve an individual note by its unique identifier.
  * Documented successful responses with note details and error responses for invalid or unavailable notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->