### PR TITLE
Add custom column width feature for Kanban board

### DIFF
--- a/app/_components/FeatureComponents/Kanban/Kanban.tsx
+++ b/app/_components/FeatureComponents/Kanban/Kanban.tsx
@@ -33,6 +33,7 @@ import { DEFAULT_KANBAN_STATUSES } from "@/app/_consts/kanban";
 import { useToast } from "@/app/_providers/ToastProvider";
 import { useSettings } from "@/app/_utils/settings-store";
 import { clampKanbanColumnWidth } from "@/app/_consts/styling";
+import { useMediaQuery } from "@/app/_hooks/useMediaQuery";
 
 interface KanbanBoardProps {
   checklist: Checklist;
@@ -71,8 +72,9 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
     ) || false;
   const { permissions } = usePermissions();
   const { kanbanColumnWidth } = useSettings();
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
   const customColumnWidth =
-    kanbanColumnWidth !== null
+    kanbanColumnWidth !== null && isDesktop
       ? clampKanbanColumnWidth(kanbanColumnWidth)
       : null;
   const {

--- a/app/_components/FeatureComponents/Kanban/Kanban.tsx
+++ b/app/_components/FeatureComponents/Kanban/Kanban.tsx
@@ -31,6 +31,8 @@ import { archiveItem, unarchiveItem } from "@/app/_server/actions/checklist-item
 import { useTranslations } from "next-intl";
 import { DEFAULT_KANBAN_STATUSES } from "@/app/_consts/kanban";
 import { useToast } from "@/app/_providers/ToastProvider";
+import { useSettings } from "@/app/_utils/settings-store";
+import { clampKanbanColumnWidth } from "@/app/_consts/styling";
 
 interface KanbanBoardProps {
   checklist: Checklist;
@@ -68,6 +70,11 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
       (sharedChecklist) => sharedChecklist.uuid === checklist.uuid,
     ) || false;
   const { permissions } = usePermissions();
+  const { kanbanColumnWidth } = useSettings();
+  const customColumnWidth =
+    kanbanColumnWidth !== null
+      ? clampKanbanColumnWidth(kanbanColumnWidth)
+      : null;
   const {
     localChecklist,
     setLocalChecklist,
@@ -257,8 +264,14 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
         style={
           columns.length <= 6
             ? ({
-              "--kanban-col-count": columns.length,
-            } as React.CSSProperties)
+                "--kanban-col-count": columns.length,
+                ...(customColumnWidth !== null
+                  ?
+                    {
+                      gridTemplateColumns: `repeat(${columns.length}, ${customColumnWidth}px)`,
+                    }
+                  : {}),
+              } as React.CSSProperties)
             : undefined
         }
       >
@@ -269,7 +282,11 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
             <div
               key={column.id}
               className={columns.length > 6 ? "flex-shrink-0" : "min-w-0"}
-              style={columns.length > 6 ? { width: "280px" } : undefined}
+              style={
+                columns.length > 6
+                  ? { width: `${customColumnWidth ?? 280}px` }
+                  : undefined
+              }
             >
               <KanbanColumn
                 checklist={localChecklist}
@@ -305,6 +322,7 @@ export const Kanban = ({ checklist, onUpdate }: KanbanBoardProps) => {
       statuses,
       handleArchiveAll,
       permissions?.canEdit,
+      customColumnWidth,
     ],
   );
 

--- a/app/_components/GlobalComponents/FormElements/ColumnWidthSlider.tsx
+++ b/app/_components/GlobalComponents/FormElements/ColumnWidthSlider.tsx
@@ -11,17 +11,9 @@ interface ColumnWidthSliderProps {
   value: number;
   onChange: (value: number) => void;
   disabled?: boolean;
-  /**
-   * When true, no custom width has been chosen and the instance default
-   * (auto-fit) is in effect. The slider shows "Auto fit" as the label until
-   * the user drags it, which switches to a custom preset.
-   */
   isDefault?: boolean;
 }
 
-// Map a px value to a friendly named preset.
-// Widths at or below the lower bound read as "Compact", above the upper as "Wide",
-// and everything in between reads as "Comfortable".
 const COMPACT_MAX = 240;
 const COMFORTABLE_MAX = 360;
 
@@ -32,11 +24,6 @@ const widthToPresetKey = (width: number): string => {
   return "settingsModal.kanbanColumnWidthWide";
 };
 
-/**
- * Slider that lets the user pick a custom width for kanban status columns.
- * Shows a friendly named preset (Compact / Comfortable / Wide) instead of a
- * raw pixel value, for better UX.
- */
 export const ColumnWidthSlider = ({
   value,
   onChange,

--- a/app/_components/GlobalComponents/FormElements/ColumnWidthSlider.tsx
+++ b/app/_components/GlobalComponents/FormElements/ColumnWidthSlider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  KANBAN_COLUMN_WIDTH_STEP,
+  MAX_KANBAN_COLUMN_WIDTH,
+  MIN_KANBAN_COLUMN_WIDTH,
+} from "@/app/_consts/styling";
+
+interface ColumnWidthSliderProps {
+  value: number;
+  onChange: (value: number) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Slider that lets the user pick a custom pixel width for kanban status columns.
+ */
+export const ColumnWidthSlider = ({
+  value,
+  onChange,
+  disabled = false,
+}: ColumnWidthSliderProps) => {
+  const t = useTranslations();
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <input
+          id="kanban-column-width"
+          type="range"
+          min={MIN_KANBAN_COLUMN_WIDTH}
+          max={MAX_KANBAN_COLUMN_WIDTH}
+          step={KANBAN_COLUMN_WIDTH_STEP}
+          value={value}
+          disabled={disabled}
+          aria-label={t("settingsModal.kanbanColumnWidth")}
+          aria-valuetext={`${value}px`}
+          onChange={(event) => onChange(Number(event.target.value))}
+          className="w-full accent-primary disabled:opacity-50"
+        />
+        <span className="w-20 shrink-0 text-right font-mono text-md lg:text-xs text-muted-foreground">
+          {value}px
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/app/_components/GlobalComponents/FormElements/ColumnWidthSlider.tsx
+++ b/app/_components/GlobalComponents/FormElements/ColumnWidthSlider.tsx
@@ -11,17 +11,42 @@ interface ColumnWidthSliderProps {
   value: number;
   onChange: (value: number) => void;
   disabled?: boolean;
+  /**
+   * When true, no custom width has been chosen and the instance default
+   * (auto-fit) is in effect. The slider shows "Auto fit" as the label until
+   * the user drags it, which switches to a custom preset.
+   */
+  isDefault?: boolean;
 }
 
+// Map a px value to a friendly named preset.
+// Widths at or below the lower bound read as "Compact", above the upper as "Wide",
+// and everything in between reads as "Comfortable".
+const COMPACT_MAX = 240;
+const COMFORTABLE_MAX = 360;
+
+const widthToPresetKey = (width: number): string => {
+  if (width <= COMPACT_MAX) return "settingsModal.kanbanColumnWidthCompact";
+  if (width <= COMFORTABLE_MAX)
+    return "settingsModal.kanbanColumnWidthComfortable";
+  return "settingsModal.kanbanColumnWidthWide";
+};
+
 /**
- * Slider that lets the user pick a custom pixel width for kanban status columns.
+ * Slider that lets the user pick a custom width for kanban status columns.
+ * Shows a friendly named preset (Compact / Comfortable / Wide) instead of a
+ * raw pixel value, for better UX.
  */
 export const ColumnWidthSlider = ({
   value,
   onChange,
   disabled = false,
+  isDefault = false,
 }: ColumnWidthSliderProps) => {
   const t = useTranslations();
+  const presetLabel = isDefault
+    ? t("settingsModal.kanbanColumnWidthAutoFit")
+    : t(widthToPresetKey(value));
 
   return (
     <div className="space-y-4">
@@ -35,12 +60,14 @@ export const ColumnWidthSlider = ({
           value={value}
           disabled={disabled}
           aria-label={t("settingsModal.kanbanColumnWidth")}
-          aria-valuetext={`${value}px`}
+          aria-valuetext={presetLabel}
           onChange={(event) => onChange(Number(event.target.value))}
           className="w-full accent-primary disabled:opacity-50"
         />
-        <span className="w-20 shrink-0 text-right font-mono text-md lg:text-xs text-muted-foreground">
-          {value}px
+        <span
+          className="w-20 shrink-0 whitespace-nowrap overflow-hidden text-right font-medium text-md lg:text-xs text-muted-foreground"
+        >
+          {presetLabel}
         </span>
       </div>
     </div>

--- a/app/_components/GlobalComponents/Modals/SettingsModals/Settings.tsx
+++ b/app/_components/GlobalComponents/Modals/SettingsModals/Settings.tsx
@@ -20,7 +20,8 @@ import Link from "next/link";
 import { useAppMode } from "@/app/_providers/AppModeProvider";
 import { useTranslations } from "next-intl";
 import { RadiusSlider } from "@/app/_components/GlobalComponents/FormElements/RadiusSlider";
-import { clampRadius } from "@/app/_consts/styling";
+import { ColumnWidthSlider } from "@/app/_components/GlobalComponents/FormElements/ColumnWidthSlider";
+import { clampRadius, clampKanbanColumnWidth } from "@/app/_consts/styling";
 import { useShowEmojis } from "@/app/_hooks/useShowEmojis";
 
 interface SettingsModalProps {
@@ -48,9 +49,13 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
     compactMode,
     borderRadius,
     setBorderRadius,
+    kanbanColumnWidth,
+    setKanbanColumnWidth,
   } = useSettings();
 
   const radius = borderRadius ?? clampRadius(appSettings?.borderRadius);
+  const columnWidth =
+    kanbanColumnWidth ?? clampKanbanColumnWidth(undefined);
   const [themes, setThemes] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -120,6 +125,29 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
         />
         <p className="text-md lg:text-xs text-muted-foreground mt-2">
           {t("settingsModal.borderRadiusDescription")}
+        </p>
+      </div>
+
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-md lg:text-sm font-medium">
+            {t("settingsModal.kanbanColumnWidth")}
+          </h3>
+          {kanbanColumnWidth !== null && (
+            <button
+              onClick={() => setKanbanColumnWidth(null)}
+              className="text-md lg:text-xs text-primary hover:underline"
+            >
+              {t("settingsModal.useInstanceDefault")}
+            </button>
+          )}
+        </div>
+        <ColumnWidthSlider
+          value={columnWidth}
+          onChange={(value) => setKanbanColumnWidth(clampKanbanColumnWidth(value))}
+        />
+        <p className="text-md lg:text-xs text-muted-foreground mt-2">
+          {t("settingsModal.kanbanColumnWidthDescription")}
         </p>
       </div>
 

--- a/app/_components/GlobalComponents/Modals/SettingsModals/Settings.tsx
+++ b/app/_components/GlobalComponents/Modals/SettingsModals/Settings.tsx
@@ -145,6 +145,7 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
         <ColumnWidthSlider
           value={columnWidth}
           onChange={(value) => setKanbanColumnWidth(clampKanbanColumnWidth(value))}
+          isDefault={kanbanColumnWidth === null}
         />
         <p className="text-md lg:text-xs text-muted-foreground mt-2">
           {t("settingsModal.kanbanColumnWidthDescription")}

--- a/app/_consts/styling.ts
+++ b/app/_consts/styling.ts
@@ -15,3 +15,18 @@ export const clampRadius = (value?: number): number => {
 
 export const radiusToRem = (value?: number): string =>
   `${clampRadius(value)}rem`;
+
+export const DEFAULT_KANBAN_COLUMN_WIDTH = 280;
+export const MIN_KANBAN_COLUMN_WIDTH = 200;
+export const MAX_KANBAN_COLUMN_WIDTH = 500;
+export const KANBAN_COLUMN_WIDTH_STEP = 10;
+
+export const clampKanbanColumnWidth = (value?: number): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_KANBAN_COLUMN_WIDTH;
+  }
+  return Math.min(
+    MAX_KANBAN_COLUMN_WIDTH,
+    Math.max(MIN_KANBAN_COLUMN_WIDTH, value),
+  );
+};

--- a/app/_hooks/useMediaQuery.ts
+++ b/app/_hooks/useMediaQuery.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const update = () => setMatches(mediaQuery.matches);
+
+    update();
+    mediaQuery.addEventListener("change", update);
+    return () => mediaQuery.removeEventListener("change", update);
+  }, [query]);
+
+  return matches;
+};

--- a/app/_translations/de.json
+++ b/app/_translations/de.json
@@ -1525,7 +1525,9 @@
     "viewModeGrid": "Raster",
     "borderRadius": "Eckenrundung",
     "useInstanceDefault": "Standard der Instanz verwenden",
-    "borderRadiusDescription": "Die Ecken ändern sich beim Ziehen in der gesamten App."
+    "borderRadiusDescription": "Die Ecken ändern sich beim Ziehen in der gesamten App.",
+    "kanbanColumnWidth": "Kanban-Spaltenbreite",
+    "kanbanColumnWidthDescription": "Lege eine benutzerdefinierte Breite für die Kanban-Statusspalten fest. Gilt nur für diese Browsers-Sitzung."
   },
   "migration": {
     "migrationComplete": "Migration vollständig",

--- a/app/_translations/de.json
+++ b/app/_translations/de.json
@@ -1527,7 +1527,11 @@
     "useInstanceDefault": "Standard der Instanz verwenden",
     "borderRadiusDescription": "Die Ecken ändern sich beim Ziehen in der gesamten App.",
     "kanbanColumnWidth": "Kanban-Spaltenbreite",
-    "kanbanColumnWidthDescription": "Lege eine benutzerdefinierte Breite für die Kanban-Statusspalten fest. Gilt nur für diese Browsers-Sitzung."
+    "kanbanColumnWidthDescription": "Lege eine benutzerdefinierte Breite für die Kanban-Statusspalten fest. Der Instanzstandard passt die Spalten automatisch an den verfügbaren Platz an.",
+    "kanbanColumnWidthCompact": "Kompakt",
+    "kanbanColumnWidthComfortable": "Komfortabel",
+    "kanbanColumnWidthWide": "Breit",
+    "kanbanColumnWidthAutoFit": "Auto-Anpassung"
   },
   "migration": {
     "migrationComplete": "Migration vollständig",

--- a/app/_translations/en.json
+++ b/app/_translations/en.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "Use instance default",
     "borderRadiusDescription": "Corners update across the whole app as you drag.",
     "kanbanColumnWidth": "Kanban column width",
-    "kanbanColumnWidthDescription": "Set a custom width for kanban status columns. Applies to this browser session only."
+    "kanbanColumnWidthDescription": "Set a custom width for kanban status columns. The instance default auto-fits columns to the available space.",
+    "kanbanColumnWidthCompact": "Compact",
+    "kanbanColumnWidthComfortable": "Comfortable",
+    "kanbanColumnWidthWide": "Wide",
+    "kanbanColumnWidthAutoFit": "Auto fit"
   },
   "migration": {
     "migrationComplete": "Migration Complete",

--- a/app/_translations/en.json
+++ b/app/_translations/en.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "Grid",
     "borderRadius": "Corner rounding",
     "useInstanceDefault": "Use instance default",
-    "borderRadiusDescription": "Corners update across the whole app as you drag."
+    "borderRadiusDescription": "Corners update across the whole app as you drag.",
+    "kanbanColumnWidth": "Kanban column width",
+    "kanbanColumnWidthDescription": "Set a custom width for kanban status columns. Applies to this browser session only."
   },
   "migration": {
     "migrationComplete": "Migration Complete",

--- a/app/_translations/es.json
+++ b/app/_translations/es.json
@@ -1528,7 +1528,11 @@
     "useInstanceDefault": "Usar el valor predeterminado",
     "borderRadiusDescription": "Las esquinas se actualizan en toda la aplicación mientras arrastras.",
     "kanbanColumnWidth": "Ancho de columnas de Kanban",
-    "kanbanColumnWidthDescription": "Establece un ancho personalizado para las columnas de estado de Kanban. Solo se aplica a esta sesión del navegador."
+    "kanbanColumnWidthDescription": "Establece un ancho personalizado para las columnas de estado de Kanban. El valor predeterminado de la instancia ajusta las columnas automáticamente al espacio disponible.",
+    "kanbanColumnWidthCompact": "Compacto",
+    "kanbanColumnWidthComfortable": "Confortable",
+    "kanbanColumnWidthWide": "Ancho",
+    "kanbanColumnWidthAutoFit": "Ajuste automático"
   },
   "migration": {
     "migrationComplete": "Migración Completa",

--- a/app/_translations/es.json
+++ b/app/_translations/es.json
@@ -1526,7 +1526,9 @@
     "viewModeGrid": "Cuadrícula",
     "borderRadius": "Redondeo de esquinas",
     "useInstanceDefault": "Usar el valor predeterminado",
-    "borderRadiusDescription": "Las esquinas se actualizan en toda la aplicación mientras arrastras."
+    "borderRadiusDescription": "Las esquinas se actualizan en toda la aplicación mientras arrastras.",
+    "kanbanColumnWidth": "Ancho de columnas de Kanban",
+    "kanbanColumnWidthDescription": "Establece un ancho personalizado para las columnas de estado de Kanban. Solo se aplica a esta sesión del navegador."
   },
   "migration": {
     "migrationComplete": "Migración Completa",

--- a/app/_translations/fr.json
+++ b/app/_translations/fr.json
@@ -1527,7 +1527,11 @@
     "useInstanceDefault": "Utiliser la valeur par défaut",
     "borderRadiusDescription": "Les coins se mettent à jour dans toute l'application pendant que vous glissez.",
     "kanbanColumnWidth": "Largeur des colonnes Kanban",
-    "kanbanColumnWidthDescription": "Définissez une largeur personnalisée pour les colonnes de statut Kanban. Ne s'applique qu'à cette session de navigateur."
+    "kanbanColumnWidthDescription": "Définissez une largeur personnalisée pour les colonnes de statut Kanban. La valeur par défaut de l'instance ajuste automatiquement les colonnes à l'espace disponible.",
+    "kanbanColumnWidthCompact": "Compact",
+    "kanbanColumnWidthComfortable": "Confortable",
+    "kanbanColumnWidthWide": "Large",
+    "kanbanColumnWidthAutoFit": "Ajustement auto"
   },
   "migration": {
     "migrationComplete": "Migration terminée",

--- a/app/_translations/fr.json
+++ b/app/_translations/fr.json
@@ -1525,7 +1525,9 @@
     "viewModeGrid": "Grille",
     "borderRadius": "Arrondi des coins",
     "useInstanceDefault": "Utiliser la valeur par défaut",
-    "borderRadiusDescription": "Les coins se mettent à jour dans toute l'application pendant que vous glissez."
+    "borderRadiusDescription": "Les coins se mettent à jour dans toute l'application pendant que vous glissez.",
+    "kanbanColumnWidth": "Largeur des colonnes Kanban",
+    "kanbanColumnWidthDescription": "Définissez une largeur personnalisée pour les colonnes de statut Kanban. Ne s'applique qu'à cette session de navigateur."
   },
   "migration": {
     "migrationComplete": "Migration terminée",

--- a/app/_translations/it.json
+++ b/app/_translations/it.json
@@ -1527,7 +1527,11 @@
     "useInstanceDefault": "Usa il valore predefinito",
     "borderRadiusDescription": "Gli angoli si aggiornano in tutta l'app mentre trascini.",
     "kanbanColumnWidth": "Larghezza colonne Kanban",
-    "kanbanColumnWidthDescription": "Imposta una larghezza personalizzata per le colonne di stato Kanban. Si applica solo a questa sessione del browser."
+    "kanbanColumnWidthDescription": "Imposta una larghezza personalizzata per le colonne di stato Kanban. Il valore predefinito dell'istanza adatta le colonne allo spazio disponibile.",
+    "kanbanColumnWidthCompact": "Compatto",
+    "kanbanColumnWidthComfortable": "Comodo",
+    "kanbanColumnWidthWide": "Largo",
+    "kanbanColumnWidthAutoFit": "Adatta"
   },
   "migration": {
     "migrationComplete": "Migrazione Completata",

--- a/app/_translations/it.json
+++ b/app/_translations/it.json
@@ -1525,7 +1525,9 @@
     "viewModeGrid": "Griglia",
     "borderRadius": "Arrotondamento angoli",
     "useInstanceDefault": "Usa il valore predefinito",
-    "borderRadiusDescription": "Gli angoli si aggiornano in tutta l'app mentre trascini."
+    "borderRadiusDescription": "Gli angoli si aggiornano in tutta l'app mentre trascini.",
+    "kanbanColumnWidth": "Larghezza colonne Kanban",
+    "kanbanColumnWidthDescription": "Imposta una larghezza personalizzata per le colonne di stato Kanban. Si applica solo a questa sessione del browser."
   },
   "migration": {
     "migrationComplete": "Migrazione Completata",

--- a/app/_translations/klingon.json
+++ b/app/_translations/klingon.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "pat DIvI' yIlo'",
     "borderRadiusDescription": "bIQeqtaHvIS Hoch pat veHmey choH.",
     "kanbanColumnWidth": "Kanban veH jul",
-    "kanbanColumnWidthDescription": "Kanban veHmeyvaD nIj wIv. DIvI' neHbrowser-Sessions neH."
+    "kanbanColumnWidthDescription": "Kanban veHmeyvaD nIj wIv. DIvI' nIjDuH veHmey nIjDaj Hoch DIvI' nI.",
+    "kanbanColumnWidthCompact": "QIm",
+    "kanbanColumnWidthComfortable": "QaQ",
+    "kanbanColumnWidthWide": "jen",
+    "kanbanColumnWidthAutoFit": "nIjDuH"
   },
   "migration": {
     "migrationComplete": "choH rIn",

--- a/app/_translations/klingon.json
+++ b/app/_translations/klingon.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "Saras",
     "borderRadius": "veH lermoHghach",
     "useInstanceDefault": "pat DIvI' yIlo'",
-    "borderRadiusDescription": "bIQeqtaHvIS Hoch pat veHmey choH."
+    "borderRadiusDescription": "bIQeqtaHvIS Hoch pat veHmey choH.",
+    "kanbanColumnWidth": "Kanban veH jul",
+    "kanbanColumnWidthDescription": "Kanban veHmeyvaD nIj wIv. DIvI' neHbrowser-Sessions neH."
   },
   "migration": {
     "migrationComplete": "choH rIn",

--- a/app/_translations/ko.json
+++ b/app/_translations/ko.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "그리드",
     "borderRadius": "모서리 둥글기",
     "useInstanceDefault": "기본값 사용",
-    "borderRadiusDescription": "드래그하는 동안 앱 전체의 모서리가 즉시 바뀝니다."
+    "borderRadiusDescription": "드래그하는 동안 앱 전체의 모서리가 즉시 바뀝니다.",
+    "kanbanColumnWidth": "칸반 열 넓이",
+    "kanbanColumnWidthDescription": "칸반 상태 열에 대한 사용자 정의 넓이를 설정합니다. 이 브라우저 세션에만 적용됩니다."
   },
   "migration": {
     "migrationComplete": "마이그레이션 완료",

--- a/app/_translations/ko.json
+++ b/app/_translations/ko.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "기본값 사용",
     "borderRadiusDescription": "드래그하는 동안 앱 전체의 모서리가 즉시 바뀝니다.",
     "kanbanColumnWidth": "칸반 열 넓이",
-    "kanbanColumnWidthDescription": "칸반 상태 열에 대한 사용자 정의 넓이를 설정합니다. 이 브라우저 세션에만 적용됩니다."
+    "kanbanColumnWidthDescription": "칸반 상태 열에 대한 사용자 정의 넓이를 설정합니다. 인스턴스 기본값은 열을 사용 가능한 공간에 자동으로 맞춥니다.",
+    "kanbanColumnWidthCompact": "좁은",
+    "kanbanColumnWidthComfortable": "보통",
+    "kanbanColumnWidthWide": "넓은",
+    "kanbanColumnWidthAutoFit": "자동 맞춤"
   },
   "migration": {
     "migrationComplete": "마이그레이션 완료",

--- a/app/_translations/nl.json
+++ b/app/_translations/nl.json
@@ -1527,7 +1527,11 @@
     "useInstanceDefault": "Standaard van instantie gebruiken",
     "borderRadiusDescription": "De hoeken passen zich in de hele app aan terwijl je sleept.",
     "kanbanColumnWidth": "Kanban-kolombreedte",
-    "kanbanColumnWidthDescription": "Stel een aangepaste breedte in voor de Kanban-statuskolommen. Geldt alleen voor deze browsersessie."
+    "kanbanColumnWidthDescription": "Stel een aangepaste breedte in voor de Kanban-statuskolommen. De standaardwaarde van de instantie past de kolommen automatisch aan de beschikbare ruimte aan.",
+    "kanbanColumnWidthCompact": "Compact",
+    "kanbanColumnWidthComfortable": "Comfortabel",
+    "kanbanColumnWidthWide": "Breed",
+    "kanbanColumnWidthAutoFit": "Auto-passen"
   },
   "migration": {
     "migrationComplete": "Migratie voltooid",

--- a/app/_translations/nl.json
+++ b/app/_translations/nl.json
@@ -1525,7 +1525,9 @@
     "viewModeGrid": "Raster",
     "borderRadius": "Hoekafronding",
     "useInstanceDefault": "Standaard van instantie gebruiken",
-    "borderRadiusDescription": "De hoeken passen zich in de hele app aan terwijl je sleept."
+    "borderRadiusDescription": "De hoeken passen zich in de hele app aan terwijl je sleept.",
+    "kanbanColumnWidth": "Kanban-kolombreedte",
+    "kanbanColumnWidthDescription": "Stel een aangepaste breedte in voor de Kanban-statuskolommen. Geldt alleen voor deze browsersessie."
   },
   "migration": {
     "migrationComplete": "Migratie voltooid",

--- a/app/_translations/pirate.json
+++ b/app/_translations/pirate.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "Grid",
     "borderRadius": "Corner roundin'",
     "useInstanceDefault": "Follow the cap'n's orders",
-    "borderRadiusDescription": "Every corner on the ship changes as ye haul the slider."
+    "borderRadiusDescription": "Every corner on the ship changes as ye haul the slider.",
+    "kanbanColumnWidth": "Kanban column width",
+    "kanbanColumnWidthDescription": "Set yer own width for the Kanban status columns. Only lasts for this browser voyage, matey."
   },
   "migration": {
     "migrationComplete": "Refit Complete",

--- a/app/_translations/pirate.json
+++ b/app/_translations/pirate.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "Follow the cap'n's orders",
     "borderRadiusDescription": "Every corner on the ship changes as ye haul the slider.",
     "kanbanColumnWidth": "Kanban column width",
-    "kanbanColumnWidthDescription": "Set yer own width for the Kanban status columns. Only lasts for this browser voyage, matey."
+    "kanbanColumnWidthDescription": "Set yer own width for the Kanban status columns. The cap'n's default fits the columns to whatever space be on deck.",
+    "kanbanColumnWidthCompact": "Cramped",
+    "kanbanColumnWidthComfortable": "Comfy",
+    "kanbanColumnWidthWide": "Roomy",
+    "kanbanColumnWidthAutoFit": "Ship-fit"
   },
   "migration": {
     "migrationComplete": "Refit Complete",

--- a/app/_translations/pl.json
+++ b/app/_translations/pl.json
@@ -1527,7 +1527,11 @@
     "useInstanceDefault": "Użyj wartości domyślnej",
     "borderRadiusDescription": "Rogi aktualizują się w całej aplikacji podczas przeciągania.",
     "kanbanColumnWidth": "Szerokość kolumn Kanban",
-    "kanbanColumnWidthDescription": "Ustaw niestandardową szerokość kolumn statusów Kanban. Dotyczy tylko tej sesji przeglądarki."
+    "kanbanColumnWidthDescription": "Ustaw niestandardową szerokość kolumn statusów Kanban. Wartość domyślna instancji automatycznie dopasowuje kolumny do dostępnej przestrzeni.",
+    "kanbanColumnWidthCompact": "Kompaktowy",
+    "kanbanColumnWidthComfortable": "Komfortowy",
+    "kanbanColumnWidthWide": "Szeroki",
+    "kanbanColumnWidthAutoFit": "Dopasowanie"
   },
   "migration": {
     "migrationComplete": "Migracja zakończona",

--- a/app/_translations/pl.json
+++ b/app/_translations/pl.json
@@ -1525,7 +1525,9 @@
     "viewModeGrid": "Siatka",
     "borderRadius": "Zaokrąglenie rogów",
     "useInstanceDefault": "Użyj wartości domyślnej",
-    "borderRadiusDescription": "Rogi aktualizują się w całej aplikacji podczas przeciągania."
+    "borderRadiusDescription": "Rogi aktualizują się w całej aplikacji podczas przeciągania.",
+    "kanbanColumnWidth": "Szerokość kolumn Kanban",
+    "kanbanColumnWidthDescription": "Ustaw niestandardową szerokość kolumn statusów Kanban. Dotyczy tylko tej sesji przeglądarki."
   },
   "migration": {
     "migrationComplete": "Migracja zakończona",

--- a/app/_translations/pt.json
+++ b/app/_translations/pt.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "Usar predefinição da instância",
     "borderRadiusDescription": "Os cantos atualizam em toda a aplicação enquanto arrasta.",
     "kanbanColumnWidth": "Largura das colunas Kanban",
-    "kanbanColumnWidthDescription": "Defina uma largura personalizada para as colunas de estado do Kanban. Aplica-se apenas a esta sessão do navegador."
+    "kanbanColumnWidthDescription": "Defina uma largura personalizada para as colunas de estado do Kanban. A predefinição da instância ajusta as colunas automaticamente ao espaço disponível.",
+    "kanbanColumnWidthCompact": "Compacto",
+    "kanbanColumnWidthComfortable": "Confortavel",
+    "kanbanColumnWidthWide": "Largo",
+    "kanbanColumnWidthAutoFit": "Ajuste auto"
   },
   "migration": {
     "migrationComplete": "Migração concluída",

--- a/app/_translations/pt.json
+++ b/app/_translations/pt.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "Grelha",
     "borderRadius": "Arredondamento dos cantos",
     "useInstanceDefault": "Usar predefinição da instância",
-    "borderRadiusDescription": "Os cantos atualizam em toda a aplicação enquanto arrasta."
+    "borderRadiusDescription": "Os cantos atualizam em toda a aplicação enquanto arrasta.",
+    "kanbanColumnWidth": "Largura das colunas Kanban",
+    "kanbanColumnWidthDescription": "Defina uma largura personalizada para as colunas de estado do Kanban. Aplica-se apenas a esta sessão do navegador."
   },
   "migration": {
     "migrationComplete": "Migração concluída",

--- a/app/_translations/ru.json
+++ b/app/_translations/ru.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "Сетка",
     "borderRadius": "Скругление углов",
     "useInstanceDefault": "Использовать значение по умолчанию",
-    "borderRadiusDescription": "Углы меняются во всём приложении по мере перетаскивания."
+    "borderRadiusDescription": "Углы меняются во всём приложении по мере перетаскивания.",
+    "kanbanColumnWidth": "Ширина колонок Kanban",
+    "kanbanColumnWidthDescription": "Установите свою ширину колонок статусов Kanban. Применяется только к этой сессии браузера."
   },
   "migration": {
     "migrationComplete": "Миграция завершена",

--- a/app/_translations/ru.json
+++ b/app/_translations/ru.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "Использовать значение по умолчанию",
     "borderRadiusDescription": "Углы меняются во всём приложении по мере перетаскивания.",
     "kanbanColumnWidth": "Ширина колонок Kanban",
-    "kanbanColumnWidthDescription": "Установите свою ширину колонок статусов Kanban. Применяется только к этой сессии браузера."
+    "kanbanColumnWidthDescription": "Установите свою ширину колонок статусов Kanban. Значение по умолчанию автоматически подгоняет колонки под доступное пространство.",
+    "kanbanColumnWidthCompact": "Компактный",
+    "kanbanColumnWidthComfortable": "Комфортный",
+    "kanbanColumnWidthWide": "Широкий",
+    "kanbanColumnWidthAutoFit": "Авто-подгон"
   },
   "migration": {
     "migrationComplete": "Миграция завершена",

--- a/app/_translations/tr.json
+++ b/app/_translations/tr.json
@@ -1552,7 +1552,9 @@
     "viewModeGrid": "Izgara",
     "borderRadius": "Köşe yuvarlaklığı",
     "useInstanceDefault": "Varsayılanı kullan",
-    "borderRadiusDescription": "Sürüklerken köşeler tüm uygulamada güncellenir."
+    "borderRadiusDescription": "Sürüklerken köşeler tüm uygulamada güncellenir.",
+    "kanbanColumnWidth": "Kanban sütun genişliği",
+    "kanbanColumnWidthDescription": "Kanban durum sütunları için özel bir genişlik ayarlayın. Yalnızca bu tarayıcı oturumu için geçerlidir."
   },
   "migration": {
     "migrationComplete": "Taşıma Tamamlandı",

--- a/app/_translations/tr.json
+++ b/app/_translations/tr.json
@@ -1554,7 +1554,11 @@
     "useInstanceDefault": "Varsayılanı kullan",
     "borderRadiusDescription": "Sürüklerken köşeler tüm uygulamada güncellenir.",
     "kanbanColumnWidth": "Kanban sütun genişliği",
-    "kanbanColumnWidthDescription": "Kanban durum sütunları için özel bir genişlik ayarlayın. Yalnızca bu tarayıcı oturumu için geçerlidir."
+    "kanbanColumnWidthDescription": "Kanban durum sütunları için özel bir genişlik ayarlayın. Örnek varsayılanı sütunları kullanılabilir alana otomatik olarak sığdırır.",
+    "kanbanColumnWidthCompact": "Kompakt",
+    "kanbanColumnWidthComfortable": "Konforli",
+    "kanbanColumnWidthWide": "Genis",
+    "kanbanColumnWidthAutoFit": "Otomatik"
   },
   "migration": {
     "migrationComplete": "Taşıma Tamamlandı",

--- a/app/_translations/zh.json
+++ b/app/_translations/zh.json
@@ -1552,7 +1552,11 @@
     "useInstanceDefault": "使用实例默认值",
     "borderRadiusDescription": "拖动时整个应用的圆角会实时更新。",
     "kanbanColumnWidth": "看板列宽度",
-    "kanbanColumnWidthDescription": "为看板状态列设置自定义宽度。仅对当前浏览器会话生效。"
+    "kanbanColumnWidthDescription": "为看板状态列设置自定义宽度。实例默认值会自动将列适应可用空间。",
+    "kanbanColumnWidthCompact": "紧凑",
+    "kanbanColumnWidthComfortable": "舒适",
+    "kanbanColumnWidthWide": "宽松",
+    "kanbanColumnWidthAutoFit": "自动适应"
   },
   "migration": {
     "migrationComplete": "迁移完成",

--- a/app/_translations/zh.json
+++ b/app/_translations/zh.json
@@ -1550,7 +1550,9 @@
     "viewModeGrid": "网格",
     "borderRadius": "圆角大小",
     "useInstanceDefault": "使用实例默认值",
-    "borderRadiusDescription": "拖动时整个应用的圆角会实时更新。"
+    "borderRadiusDescription": "拖动时整个应用的圆角会实时更新。",
+    "kanbanColumnWidth": "看板列宽度",
+    "kanbanColumnWidthDescription": "为看板状态列设置自定义宽度。仅对当前浏览器会话生效。"
   },
   "migration": {
     "migrationComplete": "迁移完成",

--- a/app/_utils/settings-store.ts
+++ b/app/_utils/settings-store.ts
@@ -43,7 +43,9 @@ interface SettingsState {
   showCompletedSuggestions: boolean;
   viewMode: 'card' | 'list' | 'grid';
   borderRadius: number | null;
+  kanbanColumnWidth: number | null;
   setBorderRadius: (radius: number | null) => void;
+  setKanbanColumnWidth: (width: number | null) => void;
   setTheme: (theme: Theme) => void;
   setShowEmojis: (show: boolean | null) => void;
   setAutosaveNotes: (enabled: boolean) => void;
@@ -69,7 +71,9 @@ export const useSettings = create<SettingsState & { isRwMarkable?: boolean }>()(
       compactMode: false,
       viewMode: 'card',
       borderRadius: null,
+      kanbanColumnWidth: null,
       setBorderRadius: (radius) => set({ borderRadius: radius }),
+      setKanbanColumnWidth: (width) => set({ kanbanColumnWidth: width }),
       setTheme: (theme) => set({ theme }),
       setShowEmojis: (show) => set({ showEmojis: show }),
       setAutosaveNotes: (enabled) => set({ autosaveNotes: enabled }),


### PR DESCRIPTION
Before

<img width="3456" height="1926" alt="CleanShot 2026-08-21 at 11  03 25@2x" src="https://github.com/user-attachments/assets/c850d5a5-eded-45f3-9c75-785f8df40994" />


After

<img width="3456" height="1926" alt="CleanShot 2026-08-21 at 11  04 47@2x" src="https://github.com/user-attachments/assets/7f8802a3-60a9-4cf4-834c-8a6504b509b1" />


Process of setting the custom width

<img width="800" height="446" alt="CleanShot 2026-08-21 at 11  03 50" src="https://github.com/user-attachments/assets/08cb299a-a98b-499b-a263-b486bd2d61c5" />


- Introduced a new `ColumnWidthSlider` component to allow users to set a custom width for Kanban columns.
- Integrated the slider into the settings modal, enabling users to adjust the column width for their current session.
- Updated Kanban component to utilize the custom column width setting, ensuring responsive layout adjustments.
- Added necessary constants and utility functions for clamping column width values.
- Updated translations for the new feature across multiple languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a Kanban column-width setting with Compact, Comfortable, Wide, and Auto-fit options.
- Added a slider in Settings to adjust or reset column width.
- Kanban columns now adapt to the selected width on desktop, with horizontal scrolling when needed.

## Localization
- Added translated labels and descriptions for the new setting across supported languages.

## Bug Fixes
- Column-width values are now safely constrained to supported limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->