### PR TITLE
Implement modal enlargement state management with local storage

### DIFF
--- a/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
+++ b/app/_components/FeatureComponents/Kanban/KanbanCardDetail.tsx
@@ -419,6 +419,7 @@ export const KanbanCardDetail = ({
         size="fullscreen"
         allowEnlarge
         defaultEnlarged
+        storageKey="kanban-card-detail"
         className="lg:!max-w-[80vw] lg:!w-full lg:!h-[80vh] lg:!max-h-[80vh] max-h-[min(90dvh,100dvh)]"
       >
       <div className="kanban-card-detail-body flex min-h-0 flex-1 flex-col gap-6 lg:flex-row lg:overflow-hidden">

--- a/app/_components/GlobalComponents/Modals/Modal.tsx
+++ b/app/_components/GlobalComponents/Modals/Modal.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "../Buttons/Button";
 import { createPortal } from "react-dom";
 import { useTranslations } from "next-intl";
+import { readModalEnlarged, writeModalEnlarged } from "@/app/_utils/modal-store";
 
 interface ModalProps {
   isOpen: boolean;
@@ -19,6 +20,7 @@ interface ModalProps {
   size?: "default" | "fullscreen";
   allowEnlarge?: boolean;
   defaultEnlarged?: boolean;
+  storageKey?: string;
 }
 
 export const Modal = ({
@@ -30,11 +32,14 @@ export const Modal = ({
   size = "default",
   allowEnlarge = false,
   defaultEnlarged = false,
+  storageKey,
 }: ModalProps) => {
   const t = useTranslations();
   const modalRef = useRef<HTMLDivElement>(null);
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
-  const [isEnlarged, setIsEnlarged] = useState(defaultEnlarged);
+  const [isEnlarged, setIsEnlarged] = useState(() =>
+    readModalEnlarged(storageKey, defaultEnlarged),
+  );
 
   useEffect(() => {
     let portalRoot = document.getElementById("modal-portal-root");
@@ -91,9 +96,9 @@ export const Modal = ({
 
   useEffect(() => {
     if (isOpen) {
-      setIsEnlarged(defaultEnlarged);
+      setIsEnlarged(readModalEnlarged(storageKey, defaultEnlarged));
     }
-  }, [isOpen, defaultEnlarged]);
+  }, [isOpen, defaultEnlarged, storageKey]);
 
   if (!isOpen || !portalElement) {
     return null;
@@ -142,7 +147,13 @@ export const Modal = ({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setIsEnlarged((prev) => !prev)}
+                onClick={() =>
+                  setIsEnlarged((prev) => {
+                    const next = !prev;
+                    writeModalEnlarged(storageKey, next);
+                    return next;
+                  })
+                }
                 className="hidden lg:inline-flex h-8 w-8 p-0"
                 aria-label={
                   isEnlarged ? t("common.shrink") : t("common.enlarge")

--- a/app/_utils/modal-store.ts
+++ b/app/_utils/modal-store.ts
@@ -1,0 +1,41 @@
+const STORAGE_KEY = "modal-enlarged";
+
+type EnlargedMap = Record<string, boolean>;
+
+const readEnlargedMap = (): EnlargedMap => {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as EnlargedMap;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+};
+
+export const readModalEnlarged = (
+  storageKey: string | undefined,
+  fallback: boolean,
+): boolean => {
+  if (!storageKey) return fallback;
+  const stored = readEnlargedMap()[storageKey];
+  return typeof stored === "boolean" ? stored : fallback;
+};
+
+export const writeModalEnlarged = (
+  storageKey: string | undefined,
+  value: boolean,
+): void => {
+  if (!storageKey || typeof window === "undefined") return;
+  try {
+    const map = readEnlargedMap();
+    map[storageKey] = value;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* ignore quota / privacy mode errors */
+  }
+};


### PR DESCRIPTION
- Added storageKey prop to Modal component for managing enlarged state.
- Introduced utility functions readModalEnlarged and writeModalEnlarged to handle local storage interactions.
- Updated KanbanCardDetail to utilize the new storageKey for modal state persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modal enlargement preferences are now remembered between sessions.
  * The Kanban card detail modal reopens using its previously selected size.

* **Bug Fixes**
  * Added safeguards so modal preferences continue working when stored data is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->