### PR TITLE
 Make active nav button highlight instantly on click

### DIFF
--- a/app/_components/FeatureComponents/Sidebar/Sidebar.tsx
+++ b/app/_components/FeatureComponents/Sidebar/Sidebar.tsx
@@ -75,6 +75,8 @@ export const Sidebar = (props: SidebarProps) => {
     sidebarMode = (defaultMode as AppMode) || Modes.CHECKLISTS;
   }
 
+  const displayMode = sidebar.pendingMode ?? sidebarMode;
+
   useEffect(() => {
     if (mode !== sidebarMode) {
       setMode(sidebarMode);
@@ -122,7 +124,7 @@ export const Sidebar = (props: SidebarProps) => {
         }
         navigation={
           <SidebarNavigation
-            mode={sidebarMode}
+            mode={displayMode}
             onModeChange={sidebar.handleModeSwitch}
           />
         }

--- a/app/_hooks/useSidebar.tsx
+++ b/app/_hooks/useSidebar.tsx
@@ -1,7 +1,12 @@
-import { useRouter, usePathname } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useAppMode } from "../_providers/AppModeProvider";
 import { useNavigationGuard } from "../_providers/NavigationGuardProvider";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from "react";
 import { Checklist, Category, Note, AppMode, SanitisedUser } from "../_types";
 import { ItemTypes, Modes } from "../_types/enums";
 import { itemHref } from "../_utils/global-utils";
@@ -25,6 +30,7 @@ export const useSidebar = (props: SidebarProps) => {
 
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { mode, setMode, isInitialized, checklists, notes, selectedFilter, setSelectedFilter } = useAppMode();
   const { checkNavigation } = useNavigationGuard();
 
@@ -47,6 +53,8 @@ export const useSidebar = (props: SidebarProps) => {
   }>({ type: null, data: null });
 
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  const [pendingMode, setPendingMode] = useState<AppMode | null>(null);
 
   const collapsedCategoriesForMode = useMemo(() => {
     return new Set(collapsedCategories[mode] || []);
@@ -131,8 +139,17 @@ export const useSidebar = (props: SidebarProps) => {
   const handleModeSwitch = (newMode: AppMode) =>
     checkNavigation(() => {
       setMode(newMode);
+      setPendingMode(newMode);
       router.push("/?mode=" + newMode);
     });
+
+  useEffect(() => {
+    if (pendingMode == null) return;
+    const urlMode = searchParams.get("mode") as AppMode | null;
+    if (urlMode === pendingMode) {
+      setPendingMode(null);
+    }
+  }, [searchParams, pendingMode]);
 
   const isHomePage = pathname === "/" || pathname === "";
 
@@ -205,6 +222,7 @@ export const useSidebar = (props: SidebarProps) => {
     mode,
     isInitialized,
     handleModeSwitch,
+    pendingMode,
     modalState,
     openModal,
     closeModal,


### PR DESCRIPTION
The sidebar Lists/Notes button highlight lagged ~1s behind the click. It was driven by `sidebarMode`, which is derived from the URL query (`useSearchParams().get("mode")`) and only recomputes once `router.push` resolves - so the highlight waited a full navigation cycle.

Fix: add pendingMode state set on click and cleared once the URL's mode param catches up. The button now reads `pendingMode ?? sidebarMode`.

**Why not just use mode?**

`mode` (the `AppModeProvider` state) is updated by an async effect, while sidebarMode is synchronously derived. Each lags in a different direction, so neither alone is correct everywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kanban column widths with compact, comfortable, wide, and auto-fit options.
  * Column widths now adapt appropriately across desktop and smaller screens.
  * Improved task description editing with rich-text and minimal editing modes.
  * Added localized settings labels across supported languages.

* **Bug Fixes**
  * Prevented editor dropdowns from closing modals unexpectedly.
  * Improved dropdown visibility within modals.
  * Fixed metadata extraction and excerpt handling for shared notes.
  * Improved sidebar mode switching feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->