### PR TITLE
Note edit removes shared users

### DIFF
--- a/app/_server/actions/note/parsers.ts
+++ b/app/_server/actions/note/parsers.ts
@@ -7,6 +7,7 @@ import {
   generateUuid,
   strayMeta,
 } from "@/app/_utils/yaml-metadata-utils";
+import { SHARED_WITH_KEY } from "@/app/_consts/sharing";
 
 export const parseMarkdownNote = (
   content: string,
@@ -38,6 +39,9 @@ export const parseMarkdownNote = (
       : new Date().toISOString(),
     owner,
     isShared,
+    ...(metadata[SHARED_WITH_KEY] !== undefined && {
+      sharedWith: metadata[SHARED_WITH_KEY] as string | string[],
+    }),
     encrypted: metadata.encrypted || false,
     encryptionMethod: metadata.encryptionMethod,
     tags: Array.isArray(metadata.tags) ? metadata.tags : [],
@@ -193,6 +197,10 @@ export const noteToMarkdown = (note: Note): string => {
 
   if (note.tags && note.tags.length > 0) {
     metadata.tags = note.tags;
+  }
+
+  if (note.sharedWith !== undefined) {
+    metadata[SHARED_WITH_KEY] = note.sharedWith;
   }
 
   const frontmatter = generateYamlFrontmatter(metadata);

--- a/app/_server/actions/note/queries.ts
+++ b/app/_server/actions/note/queries.ts
@@ -130,6 +130,9 @@ export const getNoteById = async (
     encrypted: parsedData.encrypted || false,
     encryptionMethod: parsedData.encryptionMethod,
     tags: parsedData.tags || [],
+    ...(parsedData.sharedWith !== undefined && {
+      sharedWith: parsedData.sharedWith,
+    }),
     ...(parsedData.extraMetadata && {
       extraMetadata: parsedData.extraMetadata,
     }),

--- a/app/_utils/client-parser-utils.ts
+++ b/app/_utils/client-parser-utils.ts
@@ -306,6 +306,7 @@ export const parseNoteContent = (
   encrypted?: boolean;
   encryptionMethod?: "pgp" | "xchacha";
   tags?: string[];
+  sharedWith?: string | string[];
   extraMetadata?: Record<string, unknown>;
 } => {
   const { metadata, contentWithoutMetadata } = extractYamlMetadata(rawContent);
@@ -319,6 +320,9 @@ export const parseNoteContent = (
     encrypted: metadata.encrypted || false,
     encryptionMethod: metadata.encryptionMethod,
     tags,
+    ...(metadata[SHARED_WITH_KEY] !== undefined && {
+      sharedWith: metadata[SHARED_WITH_KEY] as string | string[],
+    }),
     extraMetadata: strayMeta(metadata),
   };
 };

--- a/tests/utils/note-frontmatter.test.ts
+++ b/tests/utils/note-frontmatter.test.ts
@@ -186,4 +186,125 @@ describe("note frontmatter preservation", () => {
     ).toEqual({ publish: true, weight: 1 });
     expect(keptMeta(undefined, undefined)).toBeUndefined();
   });
+
+  describe("sharedWith preservation (issue #601)", () => {
+    const SHARED_NOTE = [
+      "---",
+      "uuid: shared-uuid-1",
+      "title: Shared Note",
+      "sharedWith:",
+      "  - alice",
+      "  - bob",
+      "tags:",
+      "  - work",
+      "---",
+      "",
+      "Body of the shared note.",
+    ].join("\n");
+
+    it("parseMarkdownNote surfaces sharedWith on the parsed note", () => {
+      const note = parseMarkdownNote(
+        SHARED_NOTE,
+        "shared-note",
+        "Uncategorized",
+        "fccview",
+      );
+
+      expect(note.sharedWith).toEqual(["alice", "bob"]);
+    });
+
+    it("noteToMarkdown writes sharedWith back into the frontmatter", () => {
+      const note = parseMarkdownNote(
+        SHARED_NOTE,
+        "shared-note",
+        "Uncategorized",
+        "fccview",
+      );
+
+      const markdown = noteToMarkdown(note);
+      const metadata = metaOf(markdown);
+
+      expect(metadata.sharedWith).toEqual(["alice", "bob"]);
+    });
+
+    it("survives a parse, save, reparse round-trip with sharedWith intact", () => {
+      const first = parseMarkdownNote(
+        SHARED_NOTE,
+        "shared-note",
+        "Uncategorized",
+        "fccview",
+      );
+
+      const second = parseMarkdownNote(
+        noteToMarkdown(first),
+        "shared-note",
+        "Uncategorized",
+        "fccview",
+      );
+
+      expect(second.sharedWith).toEqual(first.sharedWith);
+      expect(second.sharedWith).toEqual(["alice", "bob"]);
+    });
+
+    it("parseNoteContent (the edit path) surfaces sharedWith", () => {
+      const parsed = parseNoteContent(SHARED_NOTE, "shared-note");
+
+      expect(parsed.extraMetadata ?? {}).not.toHaveProperty("sharedWith");
+      expect(parsed.sharedWith).toEqual(["alice", "bob"]);
+    });
+
+    it("does not drop sharedWith when the note body is edited", () => {
+      const parsed = parseNoteContent(SHARED_NOTE, "shared-note");
+
+      const editedNote = {
+        id: "shared-note",
+        uuid: parsed.uuid || "shared-uuid-1",
+        title: "Shared Note",
+        content: "Edited body text.",
+        category: "Uncategorized",
+        createdAt: "",
+        updatedAt: "",
+        sharedWith: parsed.sharedWith,
+        tags: parsed.tags,
+        extraMetadata: keptMeta(parsed.extraMetadata, undefined),
+      };
+
+      const markdown = noteToMarkdown(editedNote);
+      const metadata = metaOf(markdown);
+
+      expect(metadata.sharedWith).toEqual(["alice", "bob"]);
+      expect(markdown).toContain("Edited body text.");
+    });
+
+    it("supports a single (string) sharedWith value", () => {
+      const single = [
+        "---",
+        "uuid: single-share",
+        "title: Single Share",
+        "sharedWith: alice",
+        "---",
+        "",
+        "Body.",
+      ].join("\n");
+
+      const note = parseMarkdownNote(single, "single", "Uncategorized", "u1");
+      expect(note.sharedWith).toBe("alice");
+
+      const metadata = metaOf(noteToMarkdown(note));
+      expect(metadata.sharedWith).toBe("alice");
+    });
+
+    it("omits sharedWith from frontmatter when it was never set", () => {
+      const plain = ["---", "uuid: plain-2", "title: Plain", "---", "Body"].join(
+        "\n",
+      );
+
+      const note = parseMarkdownNote(plain, "plain", "Uncategorized", "u1");
+      expect(note.sharedWith).toBeUndefined();
+
+      const markdown = noteToMarkdown(note);
+      const metadata = metaOf(markdown);
+      expect(metadata).not.toHaveProperty("sharedWith");
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/fccview/jotty/issues/601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved note sharing information when notes are parsed, edited, saved, and reloaded.
  * Retained sharing metadata for both individual and multiple recipients.
  * Prevented sharing information from being lost during note content updates.
  * Omitted sharing metadata from saved notes when it has not been set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->