### PR TITLE
[FEAT]: Improve 'Unscheduled' section in calendar view

### DIFF
--- a/app/_hooks/kanban/useCalendarView.ts
+++ b/app/_hooks/kanban/useCalendarView.ts
@@ -33,7 +33,7 @@ export const useCalendarView = (checklist: Checklist) => {
   );
 
   const unscheduledItems = useMemo(
-    () => checklist.items.filter((item) => !item.targetDate && !item.isArchived),
+    () => checklist.items.filter((item) => !item.targetDate && !item.completed && !item.isArchived),
     [checklist.items],
   );
 


### PR DESCRIPTION
This pull request aims to address the issue #588.

As described in the issue, the calendar view of a list shows items marked as 'Completed' in the 'Unscheduled' section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed items are no longer shown among unscheduled items in the calendar view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->